### PR TITLE
Updates and fixes for the existing Docker-based hosting capability

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.env
+enferno/build/*

--- a/.env-sample
+++ b/.env-sample
@@ -3,12 +3,6 @@ FLASK_APP=run.py
 FLASK_DEBUG=0
 SQLALCHEMY_DATABASE_URI='postgresql://user:password@host/db'
 
-SESSION_REDIS='redis:///1'
-
-CELERY_BROKER_URL='redis:///10'
-CELERY_RESULT_BACKEND='redis:///11'
-
-
 FILESYSTEM_LOCAL=True
 
 # Media Import tool
@@ -65,3 +59,47 @@ DEDUP_TOOL=True
 DEDUP_LOW_DISTANCE=0.3
 DEDUP_MAX_DISTANCE=0.5
 DEDUP_BATCH_SIZE=30
+
+# Docker
+COMPOSE_PROJECT_NAME=bayanat
+POSTGRES_USER=enferno
+POSTGRES_PASSWORD=verystrongpass
+POSTGRES_DB=enferno
+PYTHONUNBUFFERED=true
+
+## Redis
+REDIS_HOSTNAME=redis
+REDIS_PASSWORD=verystrongpass
+REDIS_PORT=6379
+REDIS_BROKER_DB=2
+REDIS_DB=0
+REDIS_RESULT_DB=3
+SESSION_DB_REDIS=1
+### 
+# The following 3 values override the values above (REDIS_* and SESSION_DB_REDIS).
+# You don't need to set these unless you want to use separate Redis servers for each.
+###
+# SESSION_REDIS='redis:///1'
+# CELERY_BROKER_URL='redis:///2'
+# CELERY_RESULT_BACKEND='redis:///3'
+
+## Exposed Ports
+NGINX_PORT=8080
+
+## Initial Admin User and Password for Docker-based installations
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=verystrongpass
+
+## Docker Registry to use for the `image` tag in Docker Compose
+### This can be left blank, otherwise it should end with a `/`
+REGISTRY=''
+
+## Uncomment and set this if you want to specify the Docker image tag
+### If using a Gitlab CI/CD pipeline, this will be set automatically
+# CI_COMMIT_SHA=
+
+## Folder to store media files when running with Docker Swarm
+COMPOSE_MEDIA_DIR=/opt/bayanat/media/
+
+## Folder to PostgreSQL Database backups when running with Docker Swarm
+COMPOSE_DB_BACKUP_DIR=/opt/bayanat/postgres/

--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,16 @@ flask_session
 .history
 celerybeat-schedule.db
 .env
+exports.env
 enferno/media/*
 *.log
 *.csv
 *.xls
 *.xlsx
 .aws
+.env*
+Pipfile
+
+# Ignore scripts in `./bin/` except the entrypoint file as the Docker Compose build uses them
+bin/*
+!bin/*-entry.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM python:3.7.2-slim
+FROM python:3.8.16-slim
 
 MAINTAINER SJAC "tech@syriaaccountability.org"
 
 RUN apt-get update -y && \
-    apt-get install -y python-pip python-dev apt-utils libjpeg62-turbo-dev libzip-dev libxml2-dev libssl-dev libffi-dev libxslt1-dev  libncurses5-dev python-setuptools libpq-dev git
+    apt-get install -y python-dev apt-utils libjpeg62-turbo-dev libzip-dev libxml2-dev libssl-dev \
+    libffi-dev libxslt1-dev  libncurses5-dev python-setuptools libpq-dev git exiftool build-essential
 
 # We copy just the requirements.txt first to leverage Docker cache
 COPY ./requirements.txt /app/requirements.txt
@@ -17,15 +18,16 @@ COPY . /app
 ENV FLASK_APP=run.py
 ENV C_FORCE_ROOT="true"
 ENV SQLALCHEMY_DATABASE_URI="postgresql://enferno:verystrongpass@postgres/enferno"
-ENV CELERY_BROKER_URL="redis://redis:verystrongpass@redis:6379/10"
-ENV CELERY_RESULT_BACKEND="redis://redis:verystrongpass@redis:6379/11"
-ENV SESSION_REDIS="redis://redis:verystrongpass@redis:6379/1"
-
+ENV REDIS_HOSTNAME="redis"
+ENV REDIS_PASSWORD="verystrongpass"
+ENV REDIS_PORT=6379
+ENV REDIS_BROKER_DB=2
+ENV REDIS_DB=0
+ENV REDIS_RESULT_DB=3
+ENV SESSION_DB_REDIS=1
 
 RUN echo 'alias act="source env/bin/activate"' >> ~/.bashrc
 RUN echo 'alias ee="export FLASK_APP=run.py && export FLASK_DEBUG=0"' >> ~/.bashrc
-
-
 
 CMD [ "uwsgi", "--http", "0.0.0.0:5000", \
                "--protocol", "uwsgi", \

--- a/bin/celery-entry.sh
+++ b/bin/celery-entry.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -eu
+
+echo "Making sure the database is initialized and the admin user is present"
+
+ADMIN_USERNAME="${ADMIN_USERNAME:-admin}"
+ADMIN_PASSWORD=$ADMIN_PASSWORD
+
+flask create-db
+echo "Database is initialized"
+
+flask install --username $ADMIN_USERNAME --password $ADMIN_PASSWORD
+echo "The admin user is present"
+
+exec "$@"

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,23 @@
+version: '3.6'
+
+services:
+  celery:
+    volumes:
+      - .:/app
+  
+  nginx:
+    build: ./nginx/
+    ports:
+      - ${NGINX_PORT:-80}:80
+    profiles:
+      - nginx
+    restart: always
+    volumes:
+      - nginx:/etc/nginx
+
+  website:
+    volumes:
+      - .:/app
+
+volumes:
+  nginx: null

--- a/docker-compose.swarm.yml
+++ b/docker-compose.swarm.yml
@@ -1,0 +1,23 @@
+version: '3.6'
+
+services:
+  celery:
+    image: ${COMPOSE_REGISTRY}bayanat/celery:${CI_COMMIT_SHA}
+  
+  postgres:
+    image: ${COMPOSE_REGISTRY}bayanat/postgres:${CI_COMMIT_SHA}
+    volumes:
+      - ${COMPOSE_DB_BACKUP_DIR}:/opt/backup
+  
+  redis:
+    image: redis:4.0-alpine
+
+  website:
+    image: ${COMPOSE_REGISTRY}bayanat/website:${CI_COMMIT_SHA}
+    volumes:
+      - ${COMPOSE_MEDIA_DIR}:/app/enferno/media
+
+volumes:
+  db_data: null
+  nginx: null
+  redis_data: null

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,60 +1,48 @@
-version: '3'
+version: '3.6'
 
 services:
-  postgres:
-    container_name: postgres
-    image: 'postgres:9.5'
+  celery:
+    build: .
+    command: celery -A enferno.tasks worker -B -l info
+    depends_on:
+      - postgres
+      - redis
+    entrypoint:
+      - /bin/bash
+      - /app/bin/celery-entry.sh
     env_file:
-      - '.env'
-    volumes:
-      - './postgres-data:/var/lib/postgresql'
+      - .env
+  
+  postgres:
+    build:
+      dockerfile: ./postgres/Dockerfile
+    env_file:
+      - .env
+    environment:
+      PGDATA: /opt/postgres/data
     ports:
-      - '5432:5432'
+      - ${POSTGRES_EXTERNAL_PORT:-5432}:5432
+    volumes:
+      - db_data:/var/lib/postgresql
 
   redis:
-    container_name: redis 
-    image: 'redis:4.0-alpine'
-    command: redis-server --requirepass verystrongpass
-    volumes:
-      - './redis-data:/var/lib/redis/data'
+    command: redis-server --requirepass ${REDIS_PASSWORD:-verystrongpass}
+    image: redis:4.0-alpine
     ports:
-      - '6379:6379'
+      - ${REDIS_EXTERNAL_PORT:-6379}:6379
+    volumes:
+      - redis_data:/var/lib/redis/data
 
   website:
-    container_name: website
     build: .
-    env_file:
-      - '.env'
-    volumes:
-      - '.:/app'
-    links:
+    depends_on:
+      - postgres
       - redis
-    ports:
-      - '8000:5000'
-
-
-  nginx:
-    container_name: nginx
-    restart: always
-    build: ./nginx/
-    ports:
-      - "80:80"
-    links:
-      - website
-
-  celery:
-    container_name: celery
-    build: .
-    command: celery worker -B -l info -A enferno.tasks
     env_file:
-      - '.env'
-    links:
-      - redis
-    volumes:
-      - '.:/enferno-plat'
-
+      - .env
+    ports:
+      - ${WEBSITE_EXTERNAL_PORT:-8000}:5000
 
 volumes:
-  enferno:
-  redis:
-  db:
+  db_data: null
+  redis_data: null

--- a/enferno/admin/models.py
+++ b/enferno/admin/models.py
@@ -3842,7 +3842,7 @@ class Settings(db.Model, BaseMixin):
     darkmode = db.Column(db.Boolean, default=False)
     api_key = db.Column(db.String)
 
-    # can be used to generate custom api keys for different integratinos
+    # can be used to generate custom api keys for different integrations
     @staticmethod
     def get_api_key():
         s = Settings.query.first()

--- a/enferno/admin/templates/admin/actors.html
+++ b/enferno/admin/templates/admin/actors.html
@@ -566,7 +566,7 @@
 
 
                 formTitle() {
-                    return this.editedItem.id ? this.translations.editActor_ : this.translations.newActr_;
+                    return this.editedItem.id ? this.translations.editActor_ : this.translations.newActor_;
                 },
                 videoPlayer() {
                     return document.querySelector("#player");

--- a/enferno/admin/templates/admin/partials/actor_dialog.html
+++ b/enferno/admin/templates/admin/partials/actor_dialog.html
@@ -7,9 +7,7 @@
                     absolute
                     color="pv"
                     dark
-
                     class="card-header"
-
             >
                 <v-toolbar-title>${formTitle} <span class="gv--text" v-if="editedItem.id"> ${editedItem.id}</span>
 

--- a/enferno/admin/templates/admin/partials/incident_dialog.html
+++ b/enferno/admin/templates/admin/partials/incident_dialog.html
@@ -7,7 +7,6 @@
                     absolute
                     color="pv"
                     dark
-
                     class="card-header"
 
             >

--- a/enferno/commands.py
+++ b/enferno/commands.py
@@ -35,27 +35,39 @@ def create_db():
 
 
 @click.command()
+@click.option('--username', default="admin", help="Username for the admin user")
+@click.option('--password', help="Password for the admin user")
 @with_appcontext
-def install():
+def install(password, username):
     """Install a default Admin user and add an Admin role to it.
     """
     admin_role = Role.query.filter(Role.name == 'Admin').first()
 
-    # check if there's an existing admin
-    if admin_role.users.all():
+    if not admin_role:
+        admin_role = Role(name='Admin').save()
+    elif admin_role.users.all():
+        # check if there's an existing admin
         click.echo('An admin user is already installed.')
         return
 
     # to make sure username doesn't already exist
     while True:
-        u = click.prompt('Admin username?', default='admin')
+        if username:
+            u = username
+        else:
+            u = click.prompt('Admin username?', default='admin')
+
         check = User.query.filter(User.username == u.lower()).first()
         if check is not None:
             click.echo('Username already exists.')
         else:
             break
 
-    p = click.prompt('Admin Password?')
+    if password:
+        p = password
+    else:
+        p = click.prompt('Admin Password?')
+    
     user = User(username=u, password=hash_password(p), active=1)
     user.name = 'Admin'
     user.roles.append(admin_role)

--- a/enferno/settings.py
+++ b/enferno/settings.py
@@ -14,8 +14,6 @@ class Config(object):
 
         return bleach.clean(identity, strip=True)
 
-
-
     SECRET_KEY = os.environ.get('SECRET_KEY')
     APP_DIR = os.path.abspath(os.path.dirname(__file__))  # This directory
     PROJECT_ROOT = os.path.abspath(os.path.join(APP_DIR, os.pardir))
@@ -23,18 +21,27 @@ class Config(object):
     DEBUG_TB_INTERCEPT_REDIRECTS = False
     CACHE_TYPE = 'simple'  # Can be "memcached", "redis", etc.
 
-    # Databaset 
+    # Database
     SQLALCHEMY_DATABASE_URI = os.environ.get('SQLALCHEMY_DATABASE_URI')
     SQLALCHEMY_TRACK_MODIFICATIONS = False
+    SQLALCHEMY_ENGINE_OPTIONS = {
+        "pool_pre_ping": os.environ.get('SQLALCHEMY_ENGINE_OPTIONS_POOL_PRE_PING', True)
+    }
 
     # Redis
-    REDIS_URL = os.environ.get('REDIS_URL', 'redis://localhost:6379/0')
+    REDIS_HOSTNAME = os.environ.get('REDIS_HOSTNAME', 'redis')
+    REDIS_PASSWORD = os.environ.get('REDIS_PASSWORD', 'verystrongpass')
+    REDIS_PORT = int(os.environ.get('REDIS_PORT', 6379))
+    REDIS_URL_BASE = f'redis://redis:{REDIS_PASSWORD}@{REDIS_HOSTNAME}:{REDIS_PORT}'
 
     # Celery
-    # Has to be in small case
-    celery_broker_url = os.environ.get('CELERY_BROKER_URL', 'redis://localhost:6379/2')
-    result_backend = os.environ.get('CELERY_RESULT_BACKEND', 'redis://localhost:6379/3')
-
+    REDIS_BROKER_DB = os.environ.get('REDIS_BROKER_DB', '2')
+    REDIS_DB = os.environ.get('REDIS_DB', '0')
+    REDIS_RESULT_DB = os.environ.get('REDIS_DB', '3')
+    REDIS_URL = os.environ.get('REDIS_URL', f'{REDIS_URL_BASE}/{REDIS_DB}')
+    ## Has to be in small case
+    celery_broker_url = os.environ.get('CELERY_BROKER_URL', f'{REDIS_URL_BASE}/{REDIS_BROKER_DB}')
+    result_backend = os.environ.get('CELERY_RESULT_BACKEND', f'{REDIS_URL_BASE}/{REDIS_RESULT_DB}')
 
     # Security
     SECURITY_REGISTERABLE = False
@@ -72,10 +79,10 @@ class Config(object):
     RECAPTCHA_PRIVATE_KEY = os.environ.get('RECAPTCHA_PRIVATE_KEY')
 
     # Session
+    SESSION_DB_REDIS = os.environ.get('SESSION_DB_REDIS', 1)
     SESSION_TYPE = 'redis'
-    SESSION_REDIS = redis.from_url(os.environ.get('SESSION_REDIS', 'redis://localhost:6379/1'))
+    SESSION_REDIS = redis.from_url(os.environ.get('SESSION_REDIS', f'{REDIS_URL_BASE}/{SESSION_DB_REDIS}'))
     PERMANENT_SESSION_LIFETIME = 3600
-
 
     # flask mail settings
     MAIL_SERVER = os.environ.get('MAIL_SERVER')
@@ -152,7 +159,6 @@ class Config(object):
     #Sheet import tool settings
     SHEET_IMPORT = (os.environ.get('SHEET_IMPORT', 'False') == 'True')
     IMPORT_DIR = 'enferno/imports'
-
 
 class ProdConfig(Config):
     """Production configuration."""

--- a/enferno/tasks/__init__.py
+++ b/enferno/tasks/__init__.py
@@ -14,14 +14,13 @@ from enferno.utils.sheet_utils import SheetUtils
 
 cfg = ProdConfig if os.environ.get('FLASK_DEBUG') == '0' else DevConfig
 
-
-
 celery = Celery('tasks', broker=cfg.celery_broker_url)
 # remove deprecated warning
 celery.conf.update(
     {'accept_content': ['pickle', 'json', 'msgpack', 'yaml']})
 celery.conf.update({'result_backend': os.environ.get('CELERY_RESULT_BACKEND', cfg.result_backend)})
 celery.conf.update({'SQLALCHEMY_DATABASE_URI': os.environ.get('SQLALCHEMY_DATABASE_URI', cfg.SQLALCHEMY_DATABASE_URI)})
+celery.conf.update({'database_engine_options': cfg.SQLALCHEMY_ENGINE_OPTIONS})
 celery.conf.update({'SECRET_KEY': os.environ.get('SECRET_KEY', cfg.SECRET_KEY)})
 celery.conf.add_defaults(cfg)
 

--- a/enferno/templates/auth_layout.html
+++ b/enferno/templates/auth_layout.html
@@ -7,9 +7,7 @@
     <meta name="author" content="SJAC" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-
     <link rel="stylesheet" href="/static/css/vuetify.min.css?v={{g.version}}" />
-
 
     <link rel="shortcut icon" type="image/png" href="/static/img/favicon.ico" />
     {% block css %}{% endblock %}

--- a/enferno/templates/footer.html
+++ b/enferno/templates/footer.html
@@ -1,12 +1,12 @@
 <v-footer padless>
-    <v-col cols="12" class="text-center p-1">
-        <a href="https://syriaaccountability.org/" class="text-decoration-none" target="_blank">
-            <small class="caption d-flex justify-center align-center">
-                <img src="/static/img/sjac-logo.png" height="20" alt="" class="mx-2 ">
-                &copy; 2021 {{ _('All rights reserved.')}}
+  <v-col cols="12" class="text-center p-1">
+      <a href="https://syriaaccountability.org/" class="text-decoration-none" target="_blank">
+          <small class="caption d-flex justify-center align-center">
+              <img src="/static/img/sjac-logo.png" height="20" alt="" class="mx-2 ">
+              &copy; 2021 {{ _('All rights reserved.')}}
 
-            </small>
-        </a>
-    </v-col>
+          </small>
+      </a>
+  </v-col>
 
 </v-footer>

--- a/enferno/templates/security/login_user.html
+++ b/enferno/templates/security/login_user.html
@@ -10,9 +10,7 @@
               <v-spacer></v-spacer>
             </v-toolbar>
             <v-card-text>
-                
               <v-form
-
                 action="{{ url_for_security('login') }}"
                 method="post"
                 id="loginForm"
@@ -33,7 +31,6 @@
                 <v-text-field
                   id="password"
                   autocomplete="chrome-off"
-
                   label="Password"
                   name="password"
                   prepend-icon="mdi-lock-question"

--- a/import-data/create-labels.sql
+++ b/import-data/create-labels.sql
@@ -1,0 +1,22 @@
+INSERT INTO public.label(
+	created_at, updated_at, deleted, id, title, title_ar, comments, comments_ar, "order", verified, for_bulletin, for_actor, for_incident, for_offline, parent_label_id)
+  VALUES 
+    ('2022-06-07 16:51:17.664607', '2022-06-07 16:51:17.664607',null,1,'Type, Killing of civilians, noncombatants, or POWs','Type, Killing of civilians, noncombatants, or POWs', null, null, null, false, true, false, true, false,null),
+    ('2022-06-07 16:51:17.664607', '2022-06-07 16:51:17.664607',null,2,'Type, Destruction of civilian property','Type, Destruction of civilian property', null, null, null, false, true, false, true, false,null),
+    ('2022-06-07 16:51:17.664607', '2022-06-07 16:51:17.664607',null,3,'Type, Destruction of protected property (hospitals, schools, religious buildings)','Type, Destruction of protected property (hospitals, schools, religious buildings)', null, null, null, false, true, false, true, false,null),
+    ('2022-06-07 16:51:17.664607', '2022-06-07 16:51:17.664607',null,4,'Type, Looting of personal property','Type, Looting of personal property', null, null, null, false, true, false, true, false,null),
+    ('2022-06-07 16:51:17.664607', '2022-06-07 16:51:17.664607',null,5,'Type, Forced transfer or deportation','Type, Forced transfer or deportation', null, null, null, false, true, false, true, false,null),
+    ('2022-06-07 16:51:17.664607', '2022-06-07 16:51:17.664607',null,6,'Type, Unlawful detention','Type, Unlawful detention', null, null, null, false, true, false, true, false,null),
+    ('2022-06-07 16:51:17.664607', '2022-06-07 16:51:17.664607',null,7,'Type, Enslavement','Type, Enslavement', null, null, null, false, true, false, true, false,null),
+    ('2022-06-07 16:51:17.664607', '2022-06-07 16:51:17.664607',null,8,'Type, Kidnapping or forced disappearance ','Type, Kidnapping or forced disappearance ', null, null, null, false, true, false, true, false,null),
+    ('2022-06-07 16:51:17.664607', '2022-06-07 16:51:17.664607',null,9,'Type, Torture or indications of torture','Type, Torture or indications of torture', null, null, null, false, true, false, true, false,null),
+    ('2022-06-07 16:51:17.664607', '2022-06-07 16:51:17.664607',null,10,'Type, Rape or sexual violence','Type, Rape or sexual violence', null, null, null, false, true, false, true, false,null),
+    ('2022-06-07 16:51:17.664607', '2022-06-07 16:51:17.664607',null,11,'Type, Persecution based on political, racial, ethnic, gender, or sexual orientation','Type, Persecution based on political, racial, ethnic, gender, or sexual orientation', null, null, null, false, true, false, true, false,null),
+    ('2022-06-07 16:51:17.664607', '2022-06-07 16:51:17.664607',null,12,'Type, Use of weapons that do not discriminate between civilian and military targets (mines, poisons, cluster munitions)','Type, Use of weapons that do not discriminate between civilian and military targets (mines, poisons, cluster munitions)', null, null, null, false, true, false, true, false,null),
+    ('2022-06-07 16:51:17.664607', '2022-06-07 16:51:17.664607',null,13,'Type, Use of chemical weapons','Type, Use of chemical weapons', null, null, null, false, true, false, true, false,null),
+    ('2022-06-07 16:51:17.664607', '2022-06-07 16:51:17.664607',null,14,'Type, Use of biological weapons','Type, Use of biological weapons', null, null, null, false, true, false, true, false,null),
+    ('2022-06-07 16:51:17.664607', '2022-06-07 16:51:17.664607',null,15,'Type, Other','Type, Other', null, null, null, false, true, false, true, false,null)
+  ON CONFLICT (id) 
+  DO 
+   UPDATE SET title = EXCLUDED.title, title_ar = EXCLUDED.title_ar, verified = EXCLUDED.verified, for_bulletin = EXCLUDED.for_bulletin, for_actor = EXCLUDED.for_actor, for_incident = EXCLUDED.for_incident, for_offline = EXCLUDED.for_offline, parent_label_id = EXCLUDED.parent_label_id;
+

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,0 +1,3 @@
+FROM postgres:14.2
+
+RUN apt update && apt install -y postgresql-14-postgis-3


### PR DESCRIPTION
## Changes

### Admin Credentials

Added the ability to set admin credentials using environment variables so they don't have to be set once everything is running. This allows for unattended deployments such as in CI/CD pipelines.

- `bin/celery-entry.sh`
  - Added to set the admin username and password using environment variables instead of having to do it manually after the containers start up. Depends on the updated version of the `flask install` command.
- `enferno/commands.py`
  - Added username and password options to the `install` command
  - It will still prompt for the username and password if they aren't provided

### PostgreSQL Connection Dropping

There was an error that caused the PostgreSQL connection to drop when the cached connection goes stale. The fix to the error required the `pool_pre_ping=True` configuration to be passed to SQL Alchemy per the [SQLAlchemy Documentation](https://docs.sqlalchemy.org/en/14/core/pooling.html#pool-disconnects). This fix uses the `SQLALCHEMY_ENGINE_OPTIONS` option of the `flask-sqlalchemy` module to set the `pool_pre_ping` configuration as outlined in the [Module Docs](https://flask-sqlalchemy.palletsprojects.com/en/2.x/api/#flask_sqlalchemy.SQLAlchemy)

- `enferno/tasks/__init__.py`
  - Added `celery.conf.update({'database_engine_options': cfg.SQLALCHEMY_ENGINE_OPTIONS})` to set the value

- `enferno/settings.py`
  - Added a config for `SQLALCHEMY_ENGINE_OPTIONS` that defaults to `True`

### Redis Configuration

The existing configs for Redis were not working when running in Docker Compose. This adds configuration items to fix the issue and make the naming a bit more consistent.

- `enferno/settings.py`
  - Breaks out configuration items for Redis hostname, password, and port so we can build a `REDIS_URL_BASE` to use for the other value defaults
  - Added the `REDIS_BROKER_DB` configuration to set the database used in the default value for `celery_broker_url`
  - Added the `REDIS_DB` configuration to set the database used in the default value for `REDIS_URL`
  - Added the `REDIS_RESULT_DB` configuration to set the database used in the default value for `result_backend`
  - Set `celery_broker_url` and `result_backend` using the new Redis hostname and port values by default but still allow `CELERY_BROKER_URL` to override it when set
  - Added `SESSION_DB_REDIS` to set the session DB used in the default value for `SESSION_REDIS`
  - Build the `SESSION_REDIS` string using the separate hostname, port, and new `SESSION_DB_REDIS` values to ensure they are consistent but still allow `SESSION_REDIS` to override it when set

### `Dockerfile`

- Updated the image to `python:3.8.16-slim` because `numpy` 1.22.0 isn't supported on Python 3.7
- Changed the `apt-get install` command
  - Removed `python-pip` as it's not a package in the updated Docker image
  - Added the `exiftool` installation as that's a requirement based on [this issue](https://github.com/guinslym/pyexifinfo/issues/9)
  - Added `build-essential` as the uwgi package instructions require it
- Added the following environment variables so the Redis connection could be configured
  - `REDIS_HOSTNAME`
  - `REDIS_PASSWORD`
  - `REDIS_PORT`
  - `REDIS_BROKER_DB`
  - `REDIS_DB`
  - `REDIS_RESULT_DB`
  - `SESSION_DB_REDIS`
- Removed the following env variables as they are built using the separate `REDIS_CELERY_HOSTNAME` and `REDIS_CELERY_PASSWORD` config items
  - `CELERY_RESULT_BACKEND`
  - `CELERY_BROKER_URL`
- Removed `SESSION_REDIS` and added `SESSION_DB_REDIS` env vars as `REDIS_SESSION` is now built using the separate hostname and port values for the Redis server

### PostgreSQL Service

- Adds a Dockerfile for PostgreSQL (`postgres/Dockerfile`)
- Updates the PostgreSQL version to 14.2
- Installs the `postgresql-14-postgis-3` package during the Docker build stage so it doesn't need to be added later

### Docker Compose Changes

Adds the ability to run in a Docker Swarm cluster as well as incorporating changes to run more effectively using Docker Compose.

- `docker-compose.override.yml`
  - Docker Compose Override files are automatically used when running using the default command (`docker-compose up -d`). Using it here so the local, development specific settings aren't run in a Docker Swarm context
  - Adds the optional `nginx` service using a profile so it doesn't run by default
- `docker-compose.yml`
  - Moves the `nginx` service section to the override file as it's not usually needed during local development or in a Docker Swarm
  - Utilizes named volumes for many of the mapped volumes such as the Postgres `/opt/postgres/data` directory as that is a bit more user-friendly than mapping local volumes
  - Adds environment variables for the mapped ports so they can be changed in the `.env` file
  - Updated the `command` for the `celery` service as the `-A` flag has to be set at the global command level
  - Removed the `links` fields as those are automatically setup when running in Docker Compose so specifying them in the `links` field is redundant
- `docker-compose.swarm.yml`
  - Adds `image` tags and volumes to run in a Docker Swarm cluster
  - Adds a `COMPOSE_REGISTRY` environment variable for setting the URL for the private Docker Registry to use to store and fetch images
  - Adds a volume mapping for storing automatic PostgreSQL backups
  - Changes many of the volume maps from named volumes to mapped ones as named volumes don't work in Docker swarm without storage plugins. This allows you to just use directories shared on all Swarm nodes using something like NFS to store files

### Miscellaneous Changes

- Removed extra newlines in various files, but this is just personal preference.
- `enferno/admin/models.py`
  - Fixed minor typo in a comment
- `enferno/admin/templates/admin/actors.html`
  - Fixed a typo in the `formTitle` return statement, changing `this.translations.newActr_` to `this.translations.newActor_`
- `import-data/create-labels.sql`
  - Added to automatically create labels for war crimes
- `.env-sample`
  - Added the new, separate Redis configuration values
  - Commented out `SESSION_REDIS`, `CELERY_BROKER_URL`, and `CELERY_RESULT_BACKEND` as using the separate values for Redis hostname and such make things a bit more consistent; left an explanation for when it might be good to uncomment them for use
  - Added the other new configuration values for PostgreSQL, Docker, and the initial admin user credentials