### PR TITLE
Updates and fixes for the existing Docker-based hosting capability

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -1,28 +1,39 @@
 # Bayanat
 FLASK_APP=run.py
-FLASK_DEBUG=0 # must be always set to 0 in production deployments
+# FLASK_DEBUG must be always set to 0 in production deployments
+FLASK_DEBUG=0
 
-POSTGRES_DB=bayanat # should leave as default
+# Should leave POSTGRES_DB as the default
+POSTGRES_DB=bayanat
 
 # Uncomment the following lines if you're deploying with Docker
 # or need to supply these information, e.g. postgres or redis are
 # installed on a separate host or require authentication.
 # Otherwise you can leave commented.
 
-# POSTGRES_USER= # should leave as default
-# POSTGRES_PASSWORD= # generate secure password and setup psql accordinngly 
-# POSTGRES_HOST= # use postgres for docker, otherwise add ip/domain name
-# REDIS_HOST= # same as above, redis for docker, or ip/domain name
-# REDIS_PASSWORD= # generate secure password and setup redis accordinngly 
-# REDIS_AOF_ENABLED=no 
-# MEDIA_PATH= # use to point to 
+# Should leave POSTGRES_USER as default
+# POSTGRES_USER=postgres
+# Generate secure password for POSTGRES_PASSWORD and setup psql accordinngly 
+# POSTGRES_PASSWORD=''
+# Use `postgres` as the POSTGRES_HOST for docker, otherwise add ip/domain name
+# POSTGRES_HOST=postgres
+# Same as above, use `redis` as the REDIS_HOST for docker, or ip/domain name
+# REDIS_HOST=redis
+# generate secure password and setup redis accordinngly 
+# REDIS_PASSWORD=''
+# REDIS_AOF_ENABLED=no
+# Use MEDIA_PATH to point to a different location to store the media files
+# MEDIA_PATH=''
 
 # Secrets
-SECRET_KEY='' # generate using 'openssl rand -base64 32'
-SECURITY_PASSWORD_SALT='' # generate using 'openssl rand -base64 32'
+# Generate SECRET_KEY using 'openssl rand -base64 32'
+SECRET_KEY=''
+# Generate SECURITY_PASSWORD_SALT using 'openssl rand -base64 32'
+SECURITY_PASSWORD_SALT=''
 
 # 2FA
-SECURITY_TOTP_SECRETS='' # generate using 'openssl rand -base64 32'
+## Generate SECURITY_TOTP_SECRETS using 'openssl rand -base64 32'
+SECURITY_TOTP_SECRETS='' 
 SECURITY_TWO_FACTOR=True
 SECURITY_TWO_FACTOR_RESCUE_MAIL=''
 SECURITY_TWO_FACTOR_AUTHENTICATOR_VALIDITY=90
@@ -59,3 +70,16 @@ DEDUP_TOOL=False
 DEDUP_LOW_DISTANCE=0.3
 DEDUP_MAX_DISTANCE=0.5
 DEDUP_BATCH_SIZE=30
+
+# Admin User
+## Credentials for the initial admin user when running in Docker
+## You should change both of these
+ADMIN_USERNAME=bayanat
+ADMIN_PASSWORD=change_this_password
+
+# Docker Compose Variables
+## Use a different port to reach the services from external locations
+BAYANAT_EXTERNAL_PORT=5000
+NGINX_EXTERNAL_PORT=80
+POSTGRES_EXTERNAL_PORT=5432
+REDIS_EXTERNAL_PORT=6379

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,8 @@
+version: '3'
+
+services:
+  bayanat:
+    volumes:
+      - '${MEDIA_PATH:-./enferno/media}:/app/enferno/media:rw'
+      - './enferno/imports:/app/enferno/imports:rw'
+      - './logs:/app/logs:rw'

--- a/docker-compose.swarm.yml
+++ b/docker-compose.swarm.yml
@@ -1,0 +1,16 @@
+version: '3'
+
+services:
+  bayanat:
+    image: ${COMPOSE_REGISTRY}bayanat:${CI_COMMIT_SHA}
+
+  celery:
+    image: ${COMPOSE_REGISTRY}celery:${CI_COMMIT_SHA}
+  
+  postgres:
+    image: ${COMPOSE_REGISTRY}bayanat/postgres:${CI_COMMIT_SHA}
+    volumes:
+      - postgres_backup:/opt/backup
+
+volumes:
+  postgres_backup:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,49 +2,56 @@ version: '3'
 
 services:
   postgres:
-    container_name: postgres
     image: 'postgis/postgis:15-3.3'
-    env_file:
-      - ${ENV_FILE:-.env}
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-bayanat}
+      POSTGRES_HOST: ${POSTGRES_HOST:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-change_this_password}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
     volumes:
       - 'postgres_data:/var/lib/postgresql/data'
     ports:
-      - '127.0.0.1:5432:5432'
+      - ${POSTGRES_EXTERNAL_PORT:-5432}:5432
     read_only: true
     security_opt:
       - no-new-privileges:true
     tmpfs:
       - /var/run/postgresql
     healthcheck:
-      test: "pg_isready -d ${POSTGRES_DB} -U ${POSTGRES_USER}"
+      test: "pg_isready -d ${POSTGRES_DB:-bayanat} -U ${POSTGRES_USER:-postgres}"
       interval: 3s
       retries: 10
 
   redis:
-    container_name: redis
     image: 'redis:latest'
     ports:
-      - '127.0.0.1:6379:6379'
+      - ${REDIS_EXTERNAL_PORT:-6379}:6379
     command: redis-server --requirepass '${REDIS_PASSWORD}'
     read_only: true
     security_opt:
       - no-new-privileges:true
     volumes:
-      - './redis-data:/var/lib/redis/data:rw'
+      - redis_data:/var/lib/redis/data
     healthcheck:
       test: [ "CMD", "redis-cli", "--no-auth-warning", "-a", "${REDIS_PASSWORD}", "ping" ]
       interval: 3s
       retries: 10
 
   bayanat:
-    container_name: bayanat
     image: bayanat
     build:
       context: .
       dockerfile: ./flask/Dockerfile
       args:
         - ROLE=flask
-        - ENV_FILE=${ENV_FILE:-.env}
+    env_file: ${ENV_FILE:-.env}
+    environment:
+      ADMIN_USERNAME: ${ADMIN_USERNAME:-admin}
+      ADMIN_PASSWORD: ${ADMIN_PASSWORD:-change_this_password}
+      POSTGRES_DB: ${POSTGRES_DB:-bayanat}
+      POSTGRES_HOST: ${POSTGRES_HOST:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-change_this_password}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
     volumes:
       - '${MEDIA_PATH:-./enferno/media}:/app/enferno/media:rw'
       - './enferno/imports:/app/enferno/imports:rw'
@@ -60,17 +67,21 @@ services:
     security_opt:
       - no-new-privileges:true
     ports:
-      - '127.0.0.1:5000:5000'
+      - ${BAYANAT_EXTERNAL_PORT:-5000}:5000
 
   celery:
-    container_name: celery
     image: celery
     build:
       context: .
       dockerfile: ./flask/Dockerfile
       args:
         - ROLE=celery
-        - ENV_FILE=${ENV_FILE:-.env}
+    env_file: ${ENV_FILE:-.env}
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-bayanat}
+      POSTGRES_HOST: ${POSTGRES_HOST:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-change_this_password}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
     volumes_from:
       - bayanat
     read_only: true
@@ -85,11 +96,10 @@ services:
         condition: service_healthy
 
   nginx:
-    container_name: nginx
     restart: always
     image: 'bitnami/nginx:latest'
     ports:
-      - '80:80'
+      - ${NGINX_EXTERNAL_PORT:-80}:80
     volumes:
       - './enferno/static/:/app/static/:ro'
       - './nginx/nginx.conf:/opt/bitnami/nginx/conf/nginx.conf:ro'
@@ -105,6 +115,8 @@ services:
       test: [ "CMD", "service", "nginx", "status" ]
       interval: 3s
       retries: 10
+    profiles:
+      - nginx
 
 volumes:
   redis_data:

--- a/enferno/commands.py
+++ b/enferno/commands.py
@@ -45,8 +45,10 @@ def create_db_exts():
 
 
 @click.command()
+@click.option('--username', default="admin", help="Username for the admin user")
+@click.option('--password', help="Password for the admin user")
 @with_appcontext
-def install():
+def install(password, username):
     """Install a default Admin user and add an Admin role to it.
     """
     admin_role = Role.query.filter(Role.name == 'Admin').first()
@@ -58,14 +60,21 @@ def install():
 
     # to make sure username doesn't already exist
     while True:
-        u = click.prompt('Admin username?', default='admin')
+        if username:
+            u = username
+        else:
+            u = click.prompt('Admin username?', default='admin')
+            
         check = User.query.filter(User.username == u.lower()).first()
         if check is not None:
             click.echo('Username already exists.')
         else:
             break
+    if password:
+        p = password
+    else:
+        p = click.prompt('Admin Password?', hide_input=True)
 
-    p = click.prompt('Admin Password?', hide_input=True)
     user = User(username=u, password=hash_password(p), active=1)
     user.name = 'Admin'
     user.roles.append(admin_role)

--- a/enferno/settings.py
+++ b/enferno/settings.py
@@ -36,6 +36,9 @@ class Config(object):
         SQLALCHEMY_DATABASE_URI = F'postgresql:///{POSTGRES_DB}'
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False
+    SQLALCHEMY_ENGINE_OPTIONS = {
+        "pool_pre_ping": os.environ.get('SQLALCHEMY_ENGINE_OPTIONS_POOL_PRE_PING', True)
+    }
 
     # Redis
     REDIS_HOST = os.environ.get('REDIS_HOST', 'localhost')

--- a/enferno/tasks/__init__.py
+++ b/enferno/tasks/__init__.py
@@ -22,6 +22,7 @@ celery.conf.update(
     {'accept_content': ['pickle', 'json', 'msgpack', 'yaml']})
 celery.conf.update({'result_backend': os.environ.get('CELERY_RESULT_BACKEND', cfg.result_backend)})
 celery.conf.update({'SQLALCHEMY_DATABASE_URI': os.environ.get('SQLALCHEMY_DATABASE_URI', cfg.SQLALCHEMY_DATABASE_URI)})
+celery.conf.update({'database_engine_options': cfg.SQLALCHEMY_ENGINE_OPTIONS})
 celery.conf.update({'SECRET_KEY': os.environ.get('SECRET_KEY', cfg.SECRET_KEY)})
 celery.conf.add_defaults(cfg)
 

--- a/flask/Dockerfile
+++ b/flask/Dockerfile
@@ -1,8 +1,22 @@
 # ---- use a base image to compile requirements / save image size -----
-FROM ubuntu as base
+FROM ubuntu:20.04 as base
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update -y && \
-    apt install -yq python3-dev python3.10-venv libjpeg8-dev libzip-dev libxml2-dev libssl-dev libffi-dev libxslt1-dev libmysqlclient-dev libncurses5-dev python-setuptools python3-pip libpq-dev libimage-exiftool-perl
+    apt install -yq \
+        libffi-dev \
+        libimage-exiftool-perl \
+        libjpeg8-dev \
+        libmysqlclient-dev \
+        libncurses5-dev \
+        libpq-dev \
+        libssl-dev \
+        libxml2-dev \
+        libxslt1-dev \
+        libzip-dev \
+        python-setuptools \
+        python3.8-dev \
+        python3-pip \
+        python3.8-venv
 
 WORKDIR /app
 
@@ -34,9 +48,9 @@ ARG ROLE
 ENV ROLE=${ROLE}
 RUN echo "Building ${ROLE} container."
 RUN if [ "$ROLE" = "flask" ]; then \
-    apt update -y && apt install -yq python3-dev python3.10-venv postgis; \
+    apt update -y && apt install -yq python3.8-dev python3.8-venv postgis; \
     elif [ "$ROLE" = "celery" ]; then \
-    apt update -y && apt install -yq python3-dev python3.10-venv postgis libimage-exiftool-perl ffmpeg; \
+    apt update -y && apt install -yq python3.8-dev python3.8-venv postgis libimage-exiftool-perl ffmpeg; \
     fi
 RUN apt clean
 RUN apt autoremove
@@ -63,15 +77,14 @@ COPY . /app
 # copy compiled virtualenv
 COPY --from=base /opt/venv /opt/venv
 
-# environments are passed directly to the image
-ARG ENV_FILE
-COPY ${ENV_FILE:-.env} /app
-
 COPY --chown=bayanat:bayanat ./flask/bin/entrypoint.sh /usr/local/bin/entrypoint.sh
 
 RUN chmod 550 /usr/local/bin/entrypoint.sh
 
 ENV PATH="/opt/venv/bin:$PATH"
+
+ENV ADMIN_USERNAME=admin
+ENV ADMIN_PASSWORD=change_this_password
 
 USER bayanat
 

--- a/flask/bin/entrypoint.sh
+++ b/flask/bin/entrypoint.sh
@@ -1,10 +1,15 @@
 #!/bin/sh
 set -e
 
+ADMIN_USERNAME="${ADMIN_USERNAME:-admin}"
+ADMIN_PASSWORD=$ADMIN_PASSWORD
+
 if [ "$ROLE" = "flask" ]; then
   echo ":: Creating Bayanat Database ::"
   flask create-db-exts
   flask create-db
+  echo ":: Trying to Create Admin User ::"
+  flask install --username ${ADMIN_USERNAME:-postgres} --password ${ADMIN_PASSWORD:-change_this_password}
   echo ":: Starting Bayanat ::"
   exec uwsgi --http 0.0.0.0:5000 --protocol uwsgi --master --enable-threads --threads 2  --processes 1 --wsgi run:app
 


### PR DESCRIPTION
- `.env-sample`
  - Added external port and admin user variables
  - Moved comments to above the relevant line to prevent issues with the `env_file` directive in Docker Compose
- `docker-compose.override.yml`
  - Added
  - The override file is automatically used when running locally so it doesn't impact someone running with `docker-compose up`, but this makes it easier to use a named volume in a Docker Swarm environment
- `docker-compose.swarm.yml`
  - Added for running in a Docker Swarm Environment
  - Adds an environment variable for the built images so you can use a local Docker Registry
    - Also adds a tag for the images. `CI_COMMIT_SHA` is the Git Commit SHA and is automatically added in a Gitlab CI/CD environment
  - Added another volume for automated PostgreSQL backups
- `docker-compose.yml`
  - Move the volumes for Bayanat to the `docker-compose.override.yml` file
  - Use a named volume for the redis service
    - Removed the `rw` as that's the default
  - `bayanat` service - Set the PostgreSQL-related environment variables as well as the credentials for the initial admin user - Use `env_file` to set the environment variables
  - `celery` service
    - Set the PostgreSQL-related environment variables
    - Use `env_file` to set the environment variables
  - `postgres` service - Removed the `env_file` in favor of setting the environment variable in the `environment` section. Dokcer Compose will read the values from the `.env` file if it is there, otherwise it will use the defaults which match the values in `.env-sample`
      - This makes sure the username and password are set so the Postgres container will start up - Also added the environment section with the PostgreSQL variables to the `celery` and `bayanat` services to make sure they match
    - Added default values for the database (`-d`), and username (`-U`) arguments for the healthcheck command as it was failing when these weren't set, causing the service to show as unhealthy
  - Removed the `ENV_FILE` build argument from the `celery` and `bayanat` services in favor of the setting that at runtime using `env_file` - Copying in the `.env` file during the build is problematic as it means you have to rebuild the container to change a configuration or at least mount a new `.env` file at runtime. The `python-dotenv` package will use environment variables instead of the `.env` files anyway, so it's easier to just set them in the `env_file` section.
  - Ports
    - Removed the reference to `127.0.0.1` in the port settings as it isn't necessary and may cause issues on remote servers
    - Add environment variables for the services that expose a port so it can be easily changed
      - These will default to the current port
  - Removed the `container_name` settings on all services as this can cause problems if running multiple versions of the Bayanat system at the same time. The container names will default to `<folder name>_<service name>`, i.e. the default name for the `redis` service if the folder is named `bayanat` will be `bayanat_redis`.
- `enferno/commands.py`
  - Updates the `install` command to allow the username and password to be passed in for unattended installations using environment variables
- `enferno/settings.py`
  - See `PostgreSQL Connection Dropping` item below
- `enferno/tasks/__init__.py`
  - See `PostgreSQL Connection Dropping` item below
- `flask/bin/entrypoint.sh`
  - Create an admin user as a part of the `flask` role startup
- `flask/Dockerfile`
  - Use the `python3.8-` versions for the `python3-dev` and the `python3.10-venv` packages as `python3.10-venv` doesn't seem to exist in the apt repo and it makes sense to specify a particular version to avoid issues later if the default version updates
  - Removed the `ENV_FILE` build arg and `COPY` command in favor of using environment variables set at runtime using docker-compose (see note in `docker-compose.yml`)
  - Add the `ADMIN_USERNAME` and `ADMIN_PASSWORD` environment variables
- `flask/bin/entrypoint.sh`
  - Add the credentials for the initial admin user and pass them to the `flask install` command

### PostgreSQL Connection Dropping

There was an error that caused the PostgreSQL connection to drop when the cached connection goes stale. The fix to the error required the `pool_pre_ping=True` configuration to be passed to SQL Alchemy per the [SQLAlchemy Documentation](https://docs.sqlalchemy.org/en/14/core/pooling.html#pool-disconnects). This fix uses the `SQLALCHEMY_ENGINE_OPTIONS` option of the `flask-sqlalchemy` module to set the `pool_pre_ping` configuration as outlined in the [Module Docs](https://flask-sqlalchemy.palletsprojects.com/en/2.x/api/#flask_sqlalchemy.SQLAlchemy)

- `enferno/tasks/__init__.py`
- Added `celery.conf.update({'database_engine_options': cfg.SQLALCHEMY_ENGINE_OPTIONS})` to set the value

- `enferno/settings.py`
- Added a config for `SQLALCHEMY_ENGINE_OPTIONS` that defaults to `True`