### PR TITLE
bugfix: activities options watcher

### DIFF
--- a/enferno/admin/templates/admin/activity.html
+++ b/enferno/admin/templates/admin/activity.html
@@ -288,10 +288,6 @@
       dialog(val) {
         val || this.close();
       },
-
-      options: {
-        handler: "refresh"
-      }
     },
 
     mounted () {


### PR DESCRIPTION
Since `update:options` on table already emits (https://vuetifyjs.com/en/api/v-data-table-server/#events-update:options) when options changes we don't need separate watcher for it.
That way it will do just one request instead of two.
