### PR TITLE
Notification system 🚨

### DIFF
--- a/enferno/admin/models/Notification.py
+++ b/enferno/admin/models/Notification.py
@@ -1,0 +1,65 @@
+from datetime import datetime
+from typing import Any
+from enferno.admin.models.utils import check_roles
+from enferno.utils.date_helper import DateHelper
+from enferno.utils.logging_utils import get_logger
+from enferno.extensions import db
+from enferno.utils.base import BaseMixin
+import json
+
+logger = get_logger()
+
+
+class Notification(db.Model, BaseMixin):
+    TYPE_GENERAL = "general"
+    TYPE_UPDATE = "update"
+    TYPE_SECURITY = "security"
+
+    DELIVERY_METHOD_EMAIL = "email"
+    DELIVERY_METHOD_SMS = "sms"
+    DELIVERY_METHOD_INTERNAL = "internal"
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False, index=True)
+    user = db.relationship("User", foreign_keys=[user_id], backref="user_notifications")
+    title = db.Column(db.String, nullable=False)
+    message = db.Column(db.Text, nullable=False)
+    notification_type = db.Column(db.String, nullable=False, default=TYPE_GENERAL)
+    read_status = db.Column(db.Boolean, default=False)
+    delivery_method = db.Column(db.String, nullable=False, default=DELIVERY_METHOD_INTERNAL)
+    read_at = db.Column(db.DateTime)
+    is_urgent = db.Column(db.Boolean, default=False)
+
+    __table_args__ = (
+        db.Index("ix_notification_user_read", "user_id", "read_status"),
+        db.Index("ix_notification_user_type", "user_id", "notification_type"),
+    )
+
+    def mark_as_read(self):
+        """Marks the notification as read and sets the read timestamp."""
+        if not self.read_status:
+            self.read_status = True
+            self.read_at = datetime.now()
+            self.save()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Converts notification object to a dictionary representation."""
+        return {
+            "id": self.id,
+            "title": self.title,
+            "message": self.message,
+            "type": self.notification_type,
+            "read_status": self.read_status,
+            "read_at": DateHelper.serialize_datetime(self.read_at) if self.read_at else None,
+            "is_urgent": self.is_urgent,
+            "created_at": DateHelper.serialize_datetime(self.created_at)
+            if self.created_at
+            else None,
+            "updated_at": DateHelper.serialize_datetime(self.updated_at)
+            if self.updated_at
+            else None,
+        }
+
+    def to_json(self) -> str:
+        """Converts notification object to a JSON string."""
+        return json.dumps(self.to_dict())

--- a/enferno/admin/models/__init__.py
+++ b/enferno/admin/models/__init__.py
@@ -39,3 +39,4 @@ from .Query import Query
 from .Settings import Settings
 from .Source import Source
 from .WorkflowStatus import WorkflowStatus
+from .Notification import Notification

--- a/enferno/admin/templates/admin/jsapi.jinja2
+++ b/enferno/admin/templates/admin/jsapi.jinja2
@@ -282,6 +282,13 @@ time_: "{{ _('Time') }}",
 refreshLogs: "{{ _('Refresh available log files and select latest log file') }}",
 noLogs: "{{ _('No log files available') }}",
 
+// Notifications
+URGENT_: "{{ _('URGENT') }}",
+noNotificationsYet_: "{{ _('No notifications yet') }}",
+noNotificationsYetDescription_: "{{ _("You haven't received any notifications yet. When you do, they'll appear here.") }}",
+loadMore_: "{{ _('Load more') }}",
+noMoreNotificationsToLoad_: "{{ _('No more notifications to load.') }}",
+
 // Activity Search Box
 user_: "{{ _('User') }}",
 selType_: "{{ _('Select Type') }}",

--- a/enferno/admin/templates/admin/system-administration.html
+++ b/enferno/admin/templates/admin/system-administration.html
@@ -34,6 +34,7 @@
                                 <v-tab value="export">{{ _('Export Tool') }}</v-tab>
                                 <v-tab value="maps">{{ _('Maps') }}</v-tab>
                                 <v-tab value="locations">{{ _('Locations') }}</v-tab>
+                                <v-tab value="mail">{{ _('Mail') }}</v-tab>
                             </v-tabs>
                         </v-card-title>
                         <v-card-text class="pa-4">
@@ -568,6 +569,7 @@
                                         </v-card-text>
                                     </v-card>
                                 </v-window-item>
+
                                 <v-window-item value="locations">
                                     <v-card :disabled="loading" :loading="loading">
                                         <v-card-text>
@@ -579,6 +581,60 @@
                                         </v-card-text>
                                     </v-card>
                                 </v-window-item>
+
+                                <v-window-item value="mail">
+                                    <v-card :disabled="loading" :loading="loading">
+                                        <v-card-text>
+                                            <v-switch color="primary" label="{{ _('Enable Mail System') }}"
+                                                      v-model="eitem.MAIL_ENABLED"
+                                                      persistent-hint
+                                                      hint="{{ _('Enables sending emails from Bayanat.') }}">
+                                            </v-switch>
+
+                                            <v-slide-y-transition>
+                                                <v-sheet v-show="eitem.MAIL_ENABLED" class=" pa-4 grey lighten-4">
+                                                    <v-text-field class="mb-9" label="{{ _('Mail Server') }}"
+                                                                  persistent-hint
+                                                                  hint="{{ _('SMTP server for sending emails.') }}"
+                                                                  v-model="eitem.MAIL_SERVER"></v-text-field>
+
+                                                    <v-text-field class="mb-9" label="{{ _('Mail Port') }}"
+                                                                  persistent-hint
+                                                                  hint="{{ _('Port for SMTP server.') }}"
+                                                                  v-model.number="eitem.MAIL_PORT"></v-text-field>
+
+                                                    <v-switch color="primary" label="{{ _('Use TLS') }}"
+                                                              v-model="eitem.MAIL_USE_TLS"
+                                                              persistent-hint
+                                                              hint="{{ _('Use TLS for SMTP server.') }}"></v-switch>
+
+                                                    <v-switch color="primary" label="{{ _('Use SSL') }}"
+                                                              v-model="eitem.MAIL_USE_SSL"
+                                                              persistent-hint
+                                                              hint="{{ _('Use SSL for SMTP server.') }}"></v-switch>
+
+                                                    <v-text-field class="mb-9" label="{{ _('Mail Username') }}"
+                                                                  persistent-hint
+                                                                  hint="{{ _('Username for SMTP server.') }}"
+                                                                  v-model="eitem.MAIL_USERNAME"></v-text-field>
+
+                                                    <v-text-field class="mb-9" label="{{ _('Mail Password') }}"
+                                                                  persistent-hint
+                                                                  hint="{{ _('Password for SMTP server.') }}"
+                                                                  v-model="eitem.MAIL_PASSWORD"></v-text-field>
+
+                                                    <v-text-field class="mb-9" label="{{ _('Mail Default Sender') }}"
+                                                                  persistent-hint
+                                                                  hint="{{ _('Default sender for emails.') }}"
+                                                                  v-model="eitem.MAIL_DEFAULT_SENDER"></v-text-field>
+
+                                                </v-sheet>
+                                            </v-slide-y-transition>
+                                            
+                                        </v-card-text>
+                                    </v-card>
+                                </v-window-item>
+
                             </v-window>
 
 

--- a/enferno/admin/templates/nav-bar.html
+++ b/enferno/admin/templates/nav-bar.html
@@ -57,10 +57,26 @@
       </v-list-item>
     </v-list>
   </v-menu>
-    
+
   <v-tooltip location="bottom">
       <template v-slot:activator="{ props }">
-        <v-btn v-bind="props" icon="mdi-cog" @click="settingsDrawer=!settingsDrawer"></v-btn>
+        <v-btn v-bind="props" icon @click="toggleNotificationsDrawer()">
+          <v-badge
+            color="error"
+            :content="unreadNotificationsCount"
+            :model-value="hasUnreadNotifications"
+            :max="9"
+          >
+            <v-icon>mdi-bell</v-icon>
+          </v-badge>
+        </v-btn>
+      </template>
+      {{ _('Notifications') }}
+  </v-tooltip>
+
+  <v-tooltip location="bottom">
+      <template v-slot:activator="{ props }">
+        <v-btn v-bind="props" icon="mdi-cog" @click="toggleUserSettingsDrawer()"></v-btn>
       </template>
       {{ _('User Settings') }}
   </v-tooltip>

--- a/enferno/admin/validation/models.py
+++ b/enferno/admin/validation/models.py
@@ -1702,6 +1702,14 @@ class FullConfigValidationModel(ConfigValidationModel):
     ADV_ANALYSIS: bool
     SETUP_COMPLETE: bool = Field(default=True)
     LOCATIONS_INCLUDE_POSTAL_CODE: bool
+    MAIL_ENABLED: bool
+    MAIL_SERVER: Optional[str] = None
+    MAIL_PORT: Optional[int] = None
+    MAIL_USE_TLS: Optional[bool] = None
+    MAIL_USE_SSL: Optional[bool] = None
+    MAIL_USERNAME: Optional[str] = None
+    MAIL_PASSWORD: Optional[str] = None
+    MAIL_DEFAULT_SENDER: Optional[str] = None
     YTDLP_PROXY: Optional[str] = None
     YTDLP_ALLOWED_DOMAINS: list[str] = Field(default_factory=list)
     YTDLP_COOKIES: Optional[str] = None
@@ -1709,6 +1717,17 @@ class FullConfigValidationModel(ConfigValidationModel):
     @model_validator(mode="before")
     def ensure_setup_complete(cls, values):
         values["SETUP_COMPLETE"] = True
+        if values.get("MAIL_ENABLED"):
+            if (
+                not values.get("MAIL_SERVER")
+                or not values.get("MAIL_PORT")
+                or not values.get("MAIL_USERNAME")
+                or not values.get("MAIL_PASSWORD")
+                or not values.get("MAIL_DEFAULT_SENDER")
+            ):
+                raise ValueError(
+                    "MAIL_SERVER, MAIL_PORT, MAIL_USERNAME and MAIL_PASSWORD must be provided if MAIL_ENABLED is True"
+                )
         return values
 
     @field_validator("ITEMS_PER_PAGE_OPTIONS")

--- a/enferno/app.py
+++ b/enferno/app.py
@@ -31,7 +31,7 @@ from enferno.admin.models import (
 )
 from enferno.admin.views import admin
 from enferno.data_import.views import imports
-from enferno.extensions import db, session, babel, rds, debug_toolbar
+from enferno.extensions import db, session, babel, rds, debug_toolbar, mail
 from enferno.public.views import bp_public
 from enferno.setup.views import bp_setup
 from enferno.settings import Config
@@ -107,6 +107,7 @@ def register_extensions(app):
     session.init_app(app)
     babel.init_app(app, locale_selector=get_locale, default_domain="messages", default_locale="en")
     rds.init_app(app)
+    mail.init_app(app)
 
 
 def register_signals(app):

--- a/enferno/extensions.py
+++ b/enferno/extensions.py
@@ -8,9 +8,11 @@ from flask_session import Session
 from flask_redis import FlaskRedis
 from flask_babel import Babel
 from flask_debugtoolbar import DebugToolbarExtension
+from flask_mail import Mail
 
 db = SQLAlchemy()
 session = Session()
 rds = FlaskRedis()
 babel = Babel()
 debug_toolbar = DebugToolbarExtension()
+mail = Mail()

--- a/enferno/settings.py
+++ b/enferno/settings.py
@@ -270,6 +270,17 @@ class Config(object):
     # Location Admin Levels
     LOCATIONS_INCLUDE_POSTAL_CODE = manager.get_config("LOCATIONS_INCLUDE_POSTAL_CODE")
 
+
+    # Email Settings
+    MAIL_ENABLED = manager.get_config("MAIL_ENABLED")
+    MAIL_SERVER = manager.get_config("MAIL_SERVER")
+    MAIL_PORT = int(manager.get_config("MAIL_PORT"))
+    MAIL_USE_TLS = manager.get_config("MAIL_USE_TLS")
+    MAIL_USE_SSL = manager.get_config("MAIL_USE_SSL")
+    MAIL_USERNAME = manager.get_config("MAIL_USERNAME")
+    MAIL_PASSWORD = manager.get_config("MAIL_PASSWORD")
+    MAIL_DEFAULT_SENDER = manager.get_config("MAIL_DEFAULT_SENDER")
+
     WEB_IMPORT = manager.get_config("WEB_IMPORT")
     # YTDLP Proxy Settings
     YTDLP_PROXY = manager.get_config("YTDLP_PROXY")
@@ -415,6 +426,17 @@ class TestConfig(Config):
     SETUP_COMPLETE = False
     IMPORT_DIR = "tests/imports"
     LOCATIONS_INCLUDE_POSTAL_CODE = False
+
+    # Email test settings
+    MAIL_SERVER = "dummy-smtp-server"
+    MAIL_PORT = 587
+    MAIL_USE_TLS = True
+    MAIL_USE_SSL = False
+    MAIL_USERNAME = "dummy-username"
+    MAIL_PASSWORD = "dummy-password"
+    MAIL_DEFAULT_SENDER = "dummy-sender@example.com"
+
     YTDLP_ALLOWED_DOMAINS = ["youtube.com", "facebook.com", "instagram.com", "twitter.com"]
     YTDLP_COOKIES = ""
     YTDLP_PROXY = ""
+

--- a/enferno/static/js/components/NotificationsList.js
+++ b/enferno/static/js/components/NotificationsList.js
@@ -1,0 +1,124 @@
+const NotificationsList = Vue.defineComponent({
+    props: [
+        'isInitialLoadingNotifications',
+        'notifications',
+        'hasMoreNotifications',
+        'isLoadingMoreNotifications',
+        'maxTitleLines',
+        'maxSubtitleLines'
+    ],
+    emits: ['readNotification', 'loadNotifications'],
+    data() {
+        return {
+            translations: window.translations
+        };
+    },
+    methods: {
+        getIconFromNotification(notification) {
+            switch (notification?.type?.toLowerCase()) {
+                case 'update':
+                    return 'mdi-update';
+                case 'security':
+                    return 'mdi-security';
+                default:
+                    return 'mdi-bell';
+            }
+        },
+        getDateFromNotification(notification) {
+            return dayjs(notification?.created_at).format('MM/DD/YYYY HH:mm');
+        },
+        getLineClampStyles(lines) {
+            if (!lines) return 'white-space: normal;'
+
+            return `overflow: hidden; display: -webkit-box; -webkit-line-clamp: ${lines}; -webkit-box-orient: vertical; white-space: normal;`
+        }
+    },
+    template: `
+        <div>
+            <v-container v-if="isInitialLoadingNotifications && !notifications" class="text-center">
+                <v-progress-circular color="primary" indeterminate></v-progress-circular>
+            </v-container>
+
+            <v-container v-else-if="!isInitialLoadingNotifications && !notifications?.length">
+                <v-empty-state icon="mdi-bell">
+                    <template v-slot:media>
+                        <v-icon color="surface-variant"></v-icon>
+                    </template>
+
+                    <template v-slot:headline>
+                        <div class="text-h5">
+                            {{ translations.noNotificationsYet_ }}
+                        </div>
+                    </template>
+
+                    <template v-slot:text>
+                        <div class="text-medium-emphasis text-caption">
+                            {{ translations.noNotificationsYetDescription_ }}
+                        </div>
+                    </template>
+                </v-empty-state>
+            </v-container>
+
+            <v-container v-else class="pa-0">
+                <v-card
+                    v-for="(notification, index) in notifications"
+                    :key="index"
+                    density="compact"
+                    :variant="notification?.read_status ? 'flat' : 'tonal'"
+                    :color="notification?.read_status ? '' : 'primary'"
+                    class="mb-2"
+                    :rounded="0"
+                    @click="$emit('readNotification', notification)"
+                >
+                    <v-card-title class="pb-1 d-flex justify-space-between align-center">
+                        <div 
+                            :class="['text-body-1', { 'font-weight-bold': !notification.read_status }]" 
+                            :style="getLineClampStyles(maxTitleLines ?? 1)"
+                            v-html="notification.title"
+                        ></div>
+                        <v-tooltip location="bottom">
+                            <template v-slot:activator="{ props }">
+                                <v-icon v-bind="props" class="ml-2" size="x-small">{{ getIconFromNotification(notification) }}</v-icon>
+                            </template>
+                            {{ notification?.type }}
+                        </v-tooltip>
+                    </v-card-title>
+                    <v-card-subtitle>
+                        <div 
+                            :style="getLineClampStyles(maxSubtitleLines ?? 2)"
+                            v-html="notification.message"
+                        ></div>
+                        <div class="d-flex justify-space-between align-center my-2">
+                            <span class="text-caption">{{ getDateFromNotification(notification) }}</span>
+                            <v-chip 
+                                v-if="notification?.is_urgent" 
+                                color="error" 
+                                size="x-small" 
+                                density="compact" 
+                                variant="flat"
+                            >
+                                {{ translations.URGENT_ }}
+                            </v-chip>
+                        </div>
+                    </v-card-subtitle>
+                </v-card>
+            </v-container>
+
+            <v-btn
+                v-if="notifications?.length && hasMoreNotifications"
+                :loading="isLoadingMoreNotifications"
+                block
+                rounded="0"
+                height="48"
+                variant="text"
+                @click="$emit('loadNotifications')"
+            >
+                {{ translations.loadMore_ }}
+            </v-btn>
+
+            <v-container v-else-if="!hasMoreNotifications && notifications?.length" class="text-center text-caption py-3">
+                {{ translations.noMoreNotificationsToLoad_ }}
+            </v-container>
+        </div>
+    `
+});

--- a/enferno/static/js/mixins/global-mixin.js
+++ b/enferno/static/js/mixins/global-mixin.js
@@ -1,5 +1,5 @@
 const globalMixin = {
-  mixins: [reauthMixin],
+  mixins: [reauthMixin, notificationMixin],
   computed: {
     allowedDateFrom() {
       if (this.editedEvent?.to_date){
@@ -125,7 +125,15 @@ const globalMixin = {
             this.showSnack(err.body);
         });
     },
+    toggleUserSettingsDrawer() {
+      // Toggle the settings drawer
+      this.settingsDrawer = !this.settingsDrawer;
 
+      // Close the notifications drawer if the settings drawer is open
+      if (this.settingsDrawer) {
+        this.isNotificationsDrawerVisible = false;
+      }
+    },
     updateLang(l) {
       this.settings.language = l
       this.saveSettings();

--- a/enferno/static/js/mixins/notification-mixin.js
+++ b/enferno/static/js/mixins/notification-mixin.js
@@ -1,0 +1,192 @@
+const notificationMixin = {
+  components: {
+    'NotificationsList': NotificationsList,
+  },
+  computed: {
+    hasUnreadNotifications() {
+      return Boolean(this.unreadNotificationsCount)
+    },
+  },
+  data: () => ({
+    // notifications drawer
+    isLoadingNotificationPreferences: false,
+    isInitialLoadingNotifications: false,
+    isLoadingMoreNotifications: false,
+    isNotificationsDrawerVisible: false,
+    isNotificationsDialogFullscreen: false,
+    isNotificationsDialogVisible: false,
+    unreadNotificationsCount: 0,
+    notifications: null,
+    totalNotifications: 0,
+    hasMoreNotifications: false,
+    currentNotificationTab: 'all',
+    notificationsPagination: {
+      page: 1,
+      per_page: 10,
+    },
+    notificationPreferences: {
+      security_alerts: false,
+      system_updates: false,
+      internal_notifications: false,
+      sms: false,
+      email: false,
+    },
+    notificationIntervalId: null
+  }),
+
+  created () {
+    this.refetchNotifications();
+    this.fetchNotificationPreferences();
+
+    this.notificationIntervalId = setInterval(this.refetchNotifications, 60_000);
+    // axios.post('/admin/api/notifications/send')
+  },
+  beforeUnmount() {
+    clearInterval(this.notificationIntervalId);
+  },
+
+  methods: {
+    toggleNotificationsDialog() {
+      // Toggle the notifications dialog
+      this.isNotificationsDialogVisible = !this.isNotificationsDialogVisible;
+
+      // Close the settings dialog if the notifications dialog is open
+      if (this.isNotificationsDialogVisible) {
+        this.settingsDrawer = false;
+        this.isNotificationsDrawerVisible = false;
+
+        // Load notifications if not already loaded
+        if (!this.notifications) {
+          this.loadNotifications({ page: 1 });
+        }
+      }
+    },
+    toggleNotificationsDrawer() {
+      // Toggle the notifications drawer
+      this.isNotificationsDrawerVisible = !this.isNotificationsDrawerVisible;
+
+      // Close the settings drawer if the notifications drawer is open
+      if (this.isNotificationsDrawerVisible) {
+        this.settingsDrawer = false;
+
+        // Load notifications if not already loaded
+        if (!this.notifications) {
+          this.loadNotifications({ page: 1 });
+        }
+      }
+    },
+    resetNotificationsState() {
+      this.hasMoreNotifications = false;
+      this.notificationsPagination = {
+        page: 1,
+        per_page: 10,
+      };
+      this.notifications = [];
+    },
+    async loadNotifications(options) {
+      // Prevent concurrent loading or invalid state
+      if (this.isLoadingMoreNotifications || this.isInitialLoadingNotifications) return;
+
+      try {
+        // Set appropriate loading state
+        if (options?.page === 1) {
+          this.isInitialLoadingNotifications = true;
+          this.resetNotificationsState();
+        } else {
+          this.isLoadingMoreNotifications = true;
+        }
+
+        const nextOptions = { ...this.notificationsPagination, ...options }
+
+        if (this.currentNotificationTab !== 'all') {
+          nextOptions.status = this.currentNotificationTab;
+        }
+
+        // Construct query parameters
+        const queryParams = new URLSearchParams(nextOptions);
+        const response = await axios.get(`/admin/api/notifications?${queryParams.toString()}`);
+
+        // Destructure response data
+        const { items: nextNotifications = [], total, hasMore } = response?.data || {};
+
+        // Update state
+        this.notifications = [...(this.notifications || []), ...nextNotifications];
+        if (this.currentNotificationTab === 'all') {
+          this.totalNotifications = total || 0;
+        }
+        this.hasMoreNotifications = Boolean(hasMore);
+
+        // Increment page if more notifications are available
+        if (this.hasMoreNotifications) {
+          this.notificationsPagination = {
+            ...this.notificationsPagination,
+            page: (this.notificationsPagination.page || 1) + 1,
+          };
+        }
+      } catch (error) {
+        const errorMessage = error?.response?.data?.message || error.message || "Failed to load notifications";
+        this.showSnack(errorMessage);
+      } finally {
+        // Reset loading states
+        this.isInitialLoadingNotifications = false;
+        this.isLoadingMoreNotifications = false;
+      }
+    },
+    async readNotification(nextNotification) {
+      // Validate the notification object and its status
+      if (!nextNotification?.id || nextNotification?.read_status) return;
+
+      // Find the matching notification
+      const matchingNotification = this.notifications.find(
+        notification => notification.id === nextNotification.id
+      );
+
+      // Update the read status if the notification is found
+      if (matchingNotification) {
+        matchingNotification.read_status = true;
+
+        // Decrement unread notifications count
+        if (this.unreadNotificationsCount > 0) {
+          this.unreadNotificationsCount -= 1;
+        }
+      }
+
+      const notificationId = nextNotification.id
+      await axios.post(`/admin/api/notifications/${notificationId}/read`)
+    },
+    updateNotificationPreferences: debounce(async function () {
+      /* TODO: Update notification preferences (No endpoint yet) */
+      const payload = this.notificationPreferences
+      console.log(payload)
+      await axios.get('/settings/load')
+    }, 800),
+    async fetchNotificationPreferences() {
+      this.isLoadingNotificationPreferences = true;
+      /* TODO: Fetch notification preferences (No endpoint yet) */
+      await axios.get('/settings/load')
+      this.notificationPreferences = {
+        security_alerts: true,
+        system_updates: true,
+        internal_notifications: true,
+        sms: true,
+        email: true,
+      }
+      this.isLoadingNotificationPreferences = false;
+    },
+    async fetchUnreadNotificationCount() {
+      const response = await axios.get('/admin/api/notifications/unread/count');
+      this.unreadNotificationsCount = response?.data?.unread_count ?? 0;
+    },
+    async refetchNotifications() {
+      this.fetchUnreadNotificationCount();
+
+      if (!this.notifications) return;
+      this.loadNotifications({ page: 1 });
+    },
+  },
+  watch: {
+    currentNotificationTab() {
+      this.loadNotifications({ page: 1 });
+    }
+  },
+};

--- a/enferno/templates/layout.html
+++ b/enferno/templates/layout.html
@@ -53,6 +53,8 @@
                 {% include 'nav-bar.html' %}
                 {% include 'nav-drawer.html' %}
                 {% include 'settings_drawer.html' %}
+                {% include 'notifications_drawer.html' %}
+                {% include 'notifications_dialog.html' %}
             {% endblock %}
             {% block content %}
             {% endblock %}
@@ -105,8 +107,6 @@
 {% endif  %}
 <script src="/static/js/vuetify.min.js"></script>
 <script src="/static/js/vue-router.global.js"></script>
-<script src="/static/js/mixins/reauth-mixin.js"></script>
-<script src="/static/js/mixins/global-mixin.js"></script>
 <script src="/static/js/axios.min.js"></script>
 <script src="/static/js/dayjs.min.js"></script>
 <script src="/static/js/photoswipe/photoswipe.umd.min.js"></script>
@@ -121,13 +121,15 @@
 <script src="/static/js/Leaflet.GoogleMutant.js"></script>
 <script src="/static/js/date_fns.min.js"></script>
 
+<script src="/static/js/components/NotificationsList.js"></script>
+<script src="/static/js/common/config.js"></script>
+<script src="/static/js/mixins/reauth-mixin.js"></script>
+<script src="/static/js/mixins/notification-mixin.js"></script>
+<script src="/static/js/mixins/global-mixin.js"></script>
+
 <script>
     {%  include 'admin/jsapi.jinja2' %}
-
 </script>
-
-<script src="/static/js/common/config.js"></script>
-
 
 {% block js %}{% endblock %}
 

--- a/enferno/templates/notifications_dialog.html
+++ b/enferno/templates/notifications_dialog.html
@@ -1,0 +1,85 @@
+<v-dialog
+    v-model="isNotificationsDialogVisible"
+    :width="isNotificationsDialogFullscreen ? null : 800"
+    :fullscreen="isNotificationsDialogFullscreen"
+>
+    <v-card variant="flat">
+        <div>
+            <v-toolbar class="position-sticky top-0" style="z-index: 2;" border flat title="{{ _('Notifications') }}">
+                <template #append>
+                    <v-btn v-if="isNotificationsDialogFullscreen" icon="mdi-fullscreen-exit" @click="isNotificationsDialogFullscreen = false"></v-btn>
+                    <v-btn v-else icon="mdi-fullscreen" @click="isNotificationsDialogFullscreen = true"></v-btn>
+                    <v-btn icon="mdi-close" @click="isNotificationsDialogVisible=false"></v-btn>
+                </template>
+            </v-toolbar>
+
+            <div :class="['d-flex', { 'flex-column': $vuetify.display.mobile }]">
+                <div class="position-sticky" style="top: 66px; z-index: 1; min-width: 200px;">
+                    <v-list class="position-sticky" style="top: 66px; z-index: 1;">
+                        <v-list-item :active="currentNotificationTab === 'all'" color="primary" density="compact" slim @click="currentNotificationTab = 'all'" prepend-icon="mdi-bell" rounded="md">
+                            <v-list-item-title>{{ _('All') }}</v-list-item-title>
+                            <template #append>
+                                ${totalNotifications}
+                            </template>
+                        </v-list-item>
+                        <v-list-item :active="currentNotificationTab === 'unread'" color="primary" density="compact" slim @click="currentNotificationTab = 'unread'" prepend-icon="mdi-inbox-outline" rounded="md">
+                            <v-list-item-title>{{ _('Unread') }}</v-list-item-title>
+                            <template #append>
+                                ${unreadNotificationsCount}
+                            </template>
+                        </v-list-item>
+                        <v-list-item :active="currentNotificationTab === 'read'" color="primary" density="compact" slim @click="currentNotificationTab = 'read'" prepend-icon="mdi-inbox-full-outline" rounded="md">
+                            <v-list-item-title>{{ _('Read') }}</v-list-item-title>
+                            <template #append>
+                                ${totalNotifications - unreadNotificationsCount}
+                            </template>
+                        </v-list-item>
+                    </v-list>
+                    <v-divider v-if="$vuetify.display.mobile" style="z-index: 1;" :vertical="!$vuetify.display.mobile"></v-divider>
+                </div>
+                <v-divider v-if="!$vuetify.display.mobile" style="z-index: 1;" :vertical="!$vuetify.display.mobile"></v-divider>
+            
+                <div class="w-100">
+                    <v-window v-model="currentNotificationTab" style="min-height: calc(100vh - 251px);">
+                        <v-window-item value="all">
+                            <notifications-list
+                                :notifications="notifications"
+                                :is-initial-loading-notifications="isInitialLoadingNotifications"
+                                :has-more-notifications="hasMoreNotifications"
+                                :is-loading-more-notifications="isLoadingMoreNotifications"
+                                @read-notification="readNotification"
+                                @load-notifications="loadNotifications(notificationsPagination)"
+                                :max-title-lines="false"
+                                :max-subtitle-lines="false"
+                            />
+                        </v-window-item>
+                        <v-window-item value="unread">
+                            <notifications-list
+                                :notifications="notifications"
+                                :is-initial-loading-notifications="isInitialLoadingNotifications"
+                                :has-more-notifications="hasMoreNotifications"
+                                :is-loading-more-notifications="isLoadingMoreNotifications"
+                                @read-notification="readNotification"
+                                @load-notifications="loadNotifications(notificationsPagination)"
+                                :max-title-lines="false"
+                                :max-subtitle-lines="false"
+                            />
+                        </v-window-item>
+                        <v-window-item value="read">
+                            <notifications-list
+                                :notifications="notifications"
+                                :is-initial-loading-notifications="isInitialLoadingNotifications"
+                                :has-more-notifications="hasMoreNotifications"
+                                :is-loading-more-notifications="isLoadingMoreNotifications"
+                                @read-notification="readNotification"
+                                @load-notifications="loadNotifications(notificationsPagination)"
+                                :max-title-lines="false"
+                                :max-subtitle-lines="false"
+                            />
+                        </v-window-item>
+                    </v-window>
+                </div>
+            </div>
+        </div>
+    </v-card>
+</v-dialog>

--- a/enferno/templates/notifications_drawer.html
+++ b/enferno/templates/notifications_drawer.html
@@ -1,0 +1,33 @@
+<v-navigation-drawer
+        v-model="isNotificationsDrawerVisible"
+        location="right"
+        temporary
+        width="300"
+>
+
+    <v-card variant="flat">
+        <v-toolbar>
+            <v-toolbar-title class="text-h6">
+                {{ _('Notifications') }}
+            </v-toolbar-title>
+            <template #append>
+                <v-tooltip location="bottom">
+                    <template v-slot:activator="{ props }">
+                        <v-btn v-bind="props" icon="mdi-open-in-app" @click="toggleNotificationsDialog()"></v-btn>
+                    </template>
+                    {{ _('Open notifications dialog') }}
+                </v-tooltip>
+                <v-btn icon="mdi-close" @click="isNotificationsDrawerVisible=false"></v-btn>
+            </template>
+        </v-toolbar>
+
+        <notifications-list
+            :notifications="notifications"
+            :is-initial-loading-notifications="isInitialLoadingNotifications"
+            :has-more-notifications="hasMoreNotifications"
+            :is-loading-more-notifications="isLoadingMoreNotifications"
+            @read-notification="readNotification"
+            @load-notifications="loadNotifications(notificationsPagination)"
+        />
+    </v-card>
+</v-navigation-drawer>

--- a/enferno/templates/settings_drawer.html
+++ b/enferno/templates/settings_drawer.html
@@ -15,10 +15,10 @@
             </template>
         </v-toolbar>
 
-        <v-divider></v-divider>
+        <v-divider class="mb-4"></v-divider>
 
         <v-container class="pa-3">
-            <v-label class="mb-2 ">
+            <v-label class="mb-2 ml-2 ">
                 {{ _('Theme') }}
             </v-label>
 
@@ -39,7 +39,6 @@
                 </v-radio>
                 <v-radio
                         :value="1"
-
                         true-icon="mdi-check-circle"
                 >
                     <template #label>
@@ -49,22 +48,77 @@
 
                 </v-radio>
             </v-radio-group>
+        </v-container>
 
-            <v-divider class="mb-4"></v-divider>
-
+        <v-divider class="mb-4"></v-divider>
+        
+        <v-container class="pa-3">
             <v-label class="mb-2 ml-2 ">
                 {{ _('Security') }}
             </v-label>
-
+            
             <v-list density="compact" nav>
-
+                
                 <v-list-item href="/change">{{ _('Change Password') }}</v-list-item>
                 <v-list-item href="/tf-setup">{{ _('Two-Factor Authentication') }}</v-list-item>
                 <v-list-item href="/mf-recovery-codes">{{ _('Recovery Codes') }}</v-list-item>
                 <v-list-item href="/wan-register">{{ _('Security Keys/Passkeys') }}</v-list-item>
 
             </v-list>
-
         </v-container>
+
+        <v-divider class="mb-4"></v-divider>
+
+        <v-container class="pa-3">
+            <v-label class="mb-2 ml-2 ">
+                {{ _('Notifications') }}
+            </v-label>
+
+            <v-list
+                density="compact"
+                :disabled="isLoadingNotificationPreferences"
+                @change="updateNotificationPreferences"
+            >
+                <v-list-subheader>Notification types</v-list-subheader>
+                <v-list-item title="Security alerts">
+                    <template v-slot:append>
+                        <v-list-item-action start>
+                            <v-checkbox-btn v-model="notificationPreferences.security_alerts"></v-checkbox-btn>
+                        </v-list-item-action>
+                    </template>
+                </v-list-item>
+                <v-list-item title="System updates">
+                    <template v-slot:append>
+                        <v-list-item-action start>
+                            <v-checkbox-btn v-model="notificationPreferences.system_updates"></v-checkbox-btn>
+                        </v-list-item-action>
+                    </template>
+                </v-list-item>
+                
+                <v-list-subheader>Delivery methods</v-list-subheader>
+                <v-list-item title="Internal notifications">
+                    <template v-slot:append>
+                        <v-list-item-action start>
+                            <v-checkbox-btn v-model="notificationPreferences.internal_notifications"></v-checkbox-btn>
+                        </v-list-item-action>
+                    </template>
+                </v-list-item>
+                <v-list-item title="SMS">
+                    <template v-slot:append>
+                        <v-list-item-action start>
+                            <v-checkbox-btn v-model="notificationPreferences.sms"></v-checkbox-btn>
+                        </v-list-item-action>
+                    </template>
+                </v-list-item>
+                <v-list-item title="Email">
+                    <template v-slot:append>
+                        <v-list-item-action start>
+                            <v-checkbox-btn v-model="notificationPreferences.email"></v-checkbox-btn>
+                        </v-list-item-action>
+                    </template>
+                </v-list-item>
+            </v-list>
+        </v-container>
+            
     </v-card>
 </v-navigation-drawer>

--- a/enferno/templates/setup_wizard.html
+++ b/enferno/templates/setup_wizard.html
@@ -455,6 +455,7 @@
 
 <script src="/static/js/vuetify.min.js"></script>
 <script src="/static/js/axios.min.js"></script>
+<script src="/static/js/mixins/notification-mixin.js"></script>
 <script src="/static/js/mixins/reauth-mixin.js"></script>
 <script src="/static/js/mixins/global-mixin.js"></script>
 <script src="/static/js/vue-router.global.js"></script>

--- a/enferno/user/views.py
+++ b/enferno/user/views.py
@@ -157,7 +157,6 @@ def account() -> str:
     """
     return render_template("dashboard.html")
 
-
 @bp_user.route("/settings/")
 @auth_required("session")
 def settings() -> str:

--- a/enferno/utils/config_utils.py
+++ b/enferno/utils/config_utils.py
@@ -131,6 +131,14 @@ class ConfigManager:
             "ACTIVITIES_RETENTION": 90,
             "ADV_ANALYSIS": False,
             "LOCATIONS_INCLUDE_POSTAL_CODE": False,
+            "MAIL_ENABLED": False,
+            "MAIL_SERVER": "",
+            "MAIL_PORT": 25,
+            "MAIL_USE_TLS": False,
+            "MAIL_USE_SSL": False,
+            "MAIL_USERNAME": "",
+            "MAIL_PASSWORD": "",
+            "MAIL_DEFAULT_SENDER": "",
             "WEB_IMPORT": False,
             "YTDLP_PROXY": "",
             "YTDLP_ALLOWED_DOMAINS": [
@@ -192,6 +200,14 @@ class ConfigManager:
             "ACTIVITIES_RETENTION": "Activity Retention Period",
             "ADV_ANALYSIS": "Advanced Analysis Features",
             "LOCATIONS_INCLUDE_POSTAL_CODE": "Full Locations Include Postal Code",
+            "MAIL_ENABLED": "Mail Enabled",
+            "MAIL_SERVER": "Mail Server",
+            "MAIL_PORT": "Mail Port",
+            "MAIL_USE_TLS": "Mail Use TLS",
+            "MAIL_USE_SSL": "Mail Use SSL",
+            "MAIL_USERNAME": "Mail Username",
+            "MAIL_PASSWORD": "Mail Password",
+            "MAIL_DEFAULT_SENDER": "Mail Default Sender",
             "WEB_IMPORT": "Web Import",
             "YTDLP_PROXY": "Proxy URL to use with Web Import",
             "YTDLP_ALLOWED_DOMAINS": "Allowed Domains for Web Import",
@@ -284,6 +300,14 @@ class ConfigManager:
             "ACTIVITIES_RETENTION": int(cfg.ACTIVITIES_RETENTION.total_seconds()) / 86400,
             "ADV_ANALYSIS": cfg.ADV_ANALYSIS,
             "LOCATIONS_INCLUDE_POSTAL_CODE": cfg.LOCATIONS_INCLUDE_POSTAL_CODE,
+            "MAIL_ENABLED": cfg.MAIL_ENABLED,
+            "MAIL_SERVER": cfg.MAIL_SERVER,
+            "MAIL_PORT": cfg.MAIL_PORT,
+            "MAIL_USE_TLS": cfg.MAIL_USE_TLS,
+            "MAIL_USE_SSL": cfg.MAIL_USE_SSL,
+            "MAIL_USERNAME": cfg.MAIL_USERNAME,
+            "MAIL_PASSWORD": ConfigManager.MASK_STRING if cfg.MAIL_PASSWORD else "",
+            "MAIL_DEFAULT_SENDER": cfg.MAIL_DEFAULT_SENDER,
             "WEB_IMPORT": cfg.WEB_IMPORT,
             "YTDLP_PROXY": cfg.YTDLP_PROXY or "",
             "YTDLP_ALLOWED_DOMAINS": cfg.YTDLP_ALLOWED_DOMAINS,
@@ -305,6 +329,10 @@ class ConfigManager:
         if conf.get("AWS_SECRET_ACCESS_KEY") == ConfigManager.MASK_STRING:
             # Keep existing secret
             conf["AWS_SECRET_ACCESS_KEY"] = cfg.AWS_SECRET_ACCESS_KEY
+
+        if conf.get("MAIL_PASSWORD") == ConfigManager.MASK_STRING:
+            # Keep existing secret
+            conf["MAIL_PASSWORD"] = cfg.MAIL_PASSWORD
 
         if ConfigManager.validate(conf):
             try:

--- a/enferno/utils/notification_utils.py
+++ b/enferno/utils/notification_utils.py
@@ -1,0 +1,141 @@
+from abc import ABC, abstractmethod
+from enferno.admin.models.Notification import Notification
+from enferno.user.models import User
+from enferno.extensions import db
+from pydantic import BaseModel, model_validator
+from pydantic import ConfigDict
+from enferno.utils.logging_utils import get_logger
+from flask import render_template_string
+from enferno.extensions import mail
+from flask_mail import Message
+import logging
+
+logger = get_logger()
+
+# Configure Flask-Mail's logger to use our custom logger
+mail_logger = logging.getLogger("flask_mail")
+mail_logger.parent = logger
+mail_logger.propagate = True
+
+
+class NotificationDeliveryStrategy(ABC):
+    @abstractmethod
+    def send(self, notification: Notification) -> bool:
+        raise NotImplementedError
+
+
+class EmailNotificationDeliveryStrategy(NotificationDeliveryStrategy):
+    def send(self, notification: Notification) -> bool:
+        try:
+            # TODO: Support custom templates/jinja2 templates
+
+            if not notification.user.email:
+                logger.error("User has no email address")
+                return False
+
+            # Create the email message
+            msg = Message(
+                subject=notification.title,
+                recipients=[notification.user.email],
+                # Plain text version
+                body=f"{notification.title}\n\n{notification.message}",
+            )
+
+            # Send the email
+            mail.send(msg)
+            return True
+
+        except Exception as e:
+            logger.error(f"Failed to send email notification: {str(e)}", exc_info=True)
+            return False
+
+
+class SmsNotificationDeliveryStrategy(NotificationDeliveryStrategy):
+    def send(self, notification: Notification) -> bool:
+        # TODO: Implement SMS delivery
+        return True
+
+
+class InternalNotificationDeliveryStrategy(NotificationDeliveryStrategy):
+    def send(self, notification: Notification) -> bool:
+        return True
+
+
+class NotificationData(BaseModel):
+    user: User
+    title: str
+    message: str
+    type: str = Notification.TYPE_GENERAL
+    delivery_method: str = Notification.DELIVERY_METHOD_INTERNAL
+    is_urgent: bool = False
+
+    @model_validator(mode="after")
+    def validate_fields(self) -> "NotificationData":
+        # Validate type
+        valid_types = [
+            Notification.TYPE_GENERAL,
+            Notification.TYPE_UPDATE,
+            Notification.TYPE_SECURITY,
+        ]
+
+        self.delivery_method = self.delivery_method.lower()
+        self.type = self.type.lower()
+
+        if self.type not in valid_types:
+            raise ValueError(f"Invalid notification type. Must be one of {valid_types}")
+
+        # Validate delivery method
+        if self.delivery_method not in NotificationUtils._strategies.keys():
+            raise ValueError(
+                f"Invalid delivery method. Must be one of {NotificationUtils._strategies.keys()}"
+            )
+
+        return self
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)  # Needed for the User model
+
+
+class NotificationUtils:
+    _strategies = {
+        Notification.DELIVERY_METHOD_EMAIL: EmailNotificationDeliveryStrategy(),
+        Notification.DELIVERY_METHOD_SMS: SmsNotificationDeliveryStrategy(),
+        Notification.DELIVERY_METHOD_INTERNAL: InternalNotificationDeliveryStrategy(),
+    }
+
+    @staticmethod
+    def send_notification(
+        user: User,
+        title: str,
+        message: str,
+        type: str = Notification.TYPE_GENERAL,
+        delivery_method: str = Notification.DELIVERY_METHOD_INTERNAL,
+        is_urgent: bool = False,
+    ) -> Notification:
+        # Validate all inputs using Pydantic
+        notification_data = NotificationData(
+            user=user,
+            title=title,
+            message=message,
+            type=type,
+            delivery_method=delivery_method,
+            is_urgent=is_urgent,
+        )
+
+        # Create notification object
+        notification = Notification(
+            user=notification_data.user,
+            title=notification_data.title,
+            message=notification_data.message,
+            notification_type=notification_data.type,
+            delivery_method=notification_data.delivery_method,
+            is_urgent=notification_data.is_urgent,
+        )
+        db.session.add(notification)
+        db.session.commit()
+
+        strategy = NotificationUtils._strategies.get(notification_data.delivery_method)
+        result = strategy.send(notification)
+        if not result:
+            raise Exception("Failed to send notification")
+
+        return notification

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ docutils==0.21.2
 email-validator==2.2.0
 Flask-Babel==4.0.0
 Flask-Login==0.6.3
+Flask-Mail==0.10.0
 Flask-Principal==0.4.0
 flask-redis==0.4.0
 Flask-Script==2.0.6

--- a/tests/validations/test_validation_models.py
+++ b/tests/validations/test_validation_models.py
@@ -94,6 +94,7 @@ class TestListValidations:
             # Test-specific settings
             "ITEMS_PER_PAGE_OPTIONS": [10, 20, 30],
             "VIDEO_RATES": [0.5, 1.0, 1.5],
+            "MAIL_ENABLED": False,
         }
 
         # Test valid configuration


### PR DESCRIPTION
## Jira Issue
[Phase 1](https://syriajustice.atlassian.net/browse/BYNT-1179)
[Phase 2](https://syriajustice.atlassian.net/browse/BYNT-1180)
[Phase 3](https://syriajustice.atlassian.net/browse/BYNT-1181)
[Phase 4](https://syriajustice.atlassian.net/browse/BYNT-1182)
[Phase 5](https://syriajustice.atlassian.net/browse/BYNT-1183)
[Phase 6](https://syriajustice.atlassian.net/browse/BYNT-1184)
[Phase 7](https://syriajustice.atlassian.net/browse/BYNT-1185)
[Phase 8](https://syriajustice.atlassian.net/browse/BYNT-1186) (PENDING)
[BYNT-1249](https://syriajustice.atlassian.net/browse/BYNT-1249)
[BYNT-1254](https://syriajustice.atlassian.net/browse/BYNT-1254)
## Description
[Brief description of changes]

## Checklist
 - [ ] Tests added/updated
 - [ ] Documentation updated (if needed)
 - [ ] New strings prepared for translations
 - [ ] Billing project label added
 - [ ] API Changes (if applicable)
 - [ ] Permissions checked 
 - [ ] Endpoint tests added
## Additional Notes
`GET /admin/api/notifications` return a paginated list of all notifications for the current user (descending by created date). Accepts `page` and `per_page` query parameters. A sample response looks like below
```
{
    "currentPage": 1,
    "hasMore": false,
    "items": [],
    "perPage": 10,
    "total": 0
}
```
`GET admin/api/notifications/unread/count`: return the number of unread notifications for the current user. Will have only one field in JSON response unread_count
`POST admin/api/notifications/<int:id>/read`: mark the notification with id as read, if it belongs to the current user. Will return a message and the notification on success.
`POST admin/api/notifications/send`: A testing endpoint to send an internal test notification to the current user.
`POST admin/api/notifications/send-email`: A testing endpoint to send an email test notification to the current user. Will log error if user doesn't have an email.