### PR TITLE
bugfix: missing @celery.task decorator for web import

### DIFF
--- a/enferno/tasks/__init__.py
+++ b/enferno/tasks/__init__.py
@@ -1211,6 +1211,7 @@ def load_whisper_model_on_startup(sender, **kwargs):
         logger.info("Whisper model not loaded, transcription is disabled")
 
 
+@celery.task
 def download_media_from_web(url: str, user_id: int, batch_id: str, import_id: int) -> None:
     """Download and process media from web URL."""
     data_import = DataImport.query.get(import_id)


### PR DESCRIPTION
## Jira Issue
1. [Add links to jira issues]

## Description
whisper celery task took over this function's decorator. Restoring.

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] New strings prepared for translations
- [ ] Billing project label added

## API Changes (if applicable)
- [ ] Permissions checked
- [ ] Endpoint tests added

## Additional Notes
[Any other relevant information]
