### PR TITLE
fix clear search behavior bulletins

### DIFF
--- a/enferno/admin/templates/admin/partials/bulletin_advsearch.html
+++ b/enferno/admin/templates/admin/partials/bulletin_advsearch.html
@@ -70,7 +70,7 @@
                     ${translations.refineExtendSearch_}
                 </v-btn>
                 <v-spacer></v-spacer>
-                <v-btn @click="resetSearch" text>{{ _('Clear Search') }}</v-btn>
+                <v-btn @click="search=[{}]" text>{{ _('Clear Search') }}</v-btn>
                 <v-btn v-if="!savedSearchSelection" @click="openSaveQueryDialog" color="grey"
                        depressed>{{ _('Save Search') }}</v-btn>
                 <v-btn


### PR DESCRIPTION
## Jira Issue
1. [BYNT-691](https://syriajustice.atlassian.net/browse/BYNT-691)

## Description
When you press clear search in advance search for bulletins the search window will close and the database will do unnecessary search. This is a different behavior than the one on actors and incidents

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] New strings prepared for translations

## API Changes (if applicable)
- [ ] Permissions checked
- [ ] Endpoint tests added

## Additional Notes
[Any other relevant information]


[BYNT-691]: https://syriajustice.atlassian.net/browse/BYNT-691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ