### PR TITLE
bug: BYNT-1332 - Web Import Fails for Content With Long Titles

### DIFF
--- a/enferno/data_import/utils/media_import.py
+++ b/enferno/data_import/utils/media_import.py
@@ -485,6 +485,13 @@ class MediaImport:
         bulletin.status = "Machine Created"
         bulletin.comments = f"Created using Media Import Tool. Batch ID: {self.batch_id}."
 
+        # Handle long video titles
+        if bulletin.title and len(bulletin.title) > 255:
+            bulletin.comments += (
+                f"\nTitle truncated to 255 characters. Original title: {bulletin.title}"
+            )
+            bulletin.title = bulletin.title[:255]
+
         # Handle web import specific data
         is_web_import = self.meta.get("mode") == self.MODE_WEB
         if is_web_import:

--- a/enferno/data_import/utils/media_import.py
+++ b/enferno/data_import/utils/media_import.py
@@ -674,9 +674,8 @@ class MediaImport:
         bulletin.meta = info
 
         if len(title) > 255:
-            title = title[:255]
             bulletin.comments += f"Title truncated to 255 characters. Original title: {title}"
-        bulletin.title = title
+        bulletin.title = title[:255]
         if is_web_import:
             bulletin.title_ar = title
 

--- a/enferno/data_import/utils/media_import.py
+++ b/enferno/data_import/utils/media_import.py
@@ -677,7 +677,7 @@ class MediaImport:
             bulletin.comments += f"Title truncated to 255 characters. Original title: {title}"
         bulletin.title = title[:255]
         if is_web_import:
-            bulletin.title_ar = title
+            bulletin.title_ar = bulletin.title
 
         try:
             bulletin.save(raise_exception=True)


### PR DESCRIPTION
## Jira Issue
1. [BYNT-1332](https://syriajustice.atlassian.net/browse/BYNT-1332)

## Description
Web Import changes: 
- Truncates long video titles to 255 characters when creating bulletin and (if truncation happened) adds the non-truncated original to the comments to make it available for searches.

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] New strings prepared for translations

## API Changes (if applicable)
- [ ] Permissions checked
- [ ] Endpoint tests added

## Additional Notes
[Any other relevant information]


[BYNT-1332]: https://syriajustice.atlassian.net/browse/BYNT-1332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ