### PR TITLE
fix import of media mixin on import log

### DIFF
--- a/enferno/data_import/templates/import-log.html
+++ b/enferno/data_import/templates/import-log.html
@@ -90,6 +90,7 @@
 
 {% block js %}
 
+<script src="/static/js/mixins/media-mixin.js"></script>
 <script src="/static/js/components/BulletinCard.js"></script>
 <script src="/static/js/components/ActorProfiles.js"></script>
 <script src="/static/js/components/ActorCard.js"></script>
@@ -106,7 +107,6 @@
 <script src="/static/js/components/RelatedActorsCard.js"></script>
 <script src="/static/js/components/RelatedIncidentsCard.js"></script>
 
-<script src="/static/js/mixins/media-mixin.js"></script>
 <script src="/static/js/components/PdfViewer.js"></script>
 <script src="/static/js/components/GlobalMap.js"></script>
 <script src="/static/js/components/Visualization.js"></script>

--- a/enferno/data_import/templates/media-import.html
+++ b/enferno/data_import/templates/media-import.html
@@ -349,6 +349,7 @@
 
     <script src="/static/js/components/SearchField.js" ></script>
     <script src="/static/js/mixins/whisper-mixin.js" ></script>
+    <script src="/static/js/mixins/media-mixin.js" ></script>
 
 
 
@@ -367,7 +368,7 @@
 
         const app = createApp({
             delimiters: delimiters,
-            mixins: [globalMixin, whisperMixin],
+            mixins: [globalMixin, mediaMixin, whisperMixin],
             
             data: () => ({
                 drawer: drawer,

--- a/enferno/export/templates/export-dashboard.html
+++ b/enferno/export/templates/export-dashboard.html
@@ -102,6 +102,7 @@
 
 {% block js %}
     <script src="/static/js/videojs/video.min.js"></script>
+    <script src="/static/js/mixins/media-mixin.js"></script>
 
     <script src="/static/js/components/ExportCard.js"></script>
     <script src="/static/js/components/PreviewCard.js"></script>


### PR DESCRIPTION
## Jira Issue
1. [Add links to jira issues]

## Description
This is a bug fix to change the position of an import on the Import Log page since it's broken as mediaMixin cannot be found by ActorCard and BulletinCard components

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] New strings prepared for translations

## API Changes (if applicable)
- [ ] Permissions checked
- [ ] Endpoint tests added

## Additional Notes
[Any other relevant information]
