### PR TITLE
Auto scroll to invalid elements

### DIFF
--- a/enferno/admin/templates/admin/actors.html
+++ b/enferno/admin/templates/admin/actors.html
@@ -859,9 +859,13 @@
                     },
 
                 validateForm() {
-                    this.$refs.form.validate().then(valid => {
+                    this.$refs.form.validate().then(({ valid, errors }) => {
                         if (valid) {
                             this.save();
+                        } else {
+                            this.showSnack("{{ _('Please review the form for errors.')}}")
+                            const invalidFieldId = errors.find((e) => Boolean(e?.id))?.id
+                            scrollToElementById(invalidFieldId)
                         }
                     });
                 },

--- a/enferno/admin/templates/admin/bulletins.html
+++ b/enferno/admin/templates/admin/bulletins.html
@@ -936,9 +936,13 @@
                     },
 
                     validateForm() {
-                        this.$refs.form.validate().then(valid => {
+                        this.$refs.form.validate().then(({ valid, errors }) => {
                             if (valid) {
                                 this.save();
+                            } else {
+                                this.showSnack("{{ _('Please review the form for errors.')}}")
+                                const invalidFieldId = errors.find((e) => Boolean(e?.id))?.id
+                                scrollToElementById(invalidFieldId)
                             }
                         });
                     },

--- a/enferno/admin/templates/admin/incidents.html
+++ b/enferno/admin/templates/admin/incidents.html
@@ -790,9 +790,13 @@
                 },
 
                 validateForm() {
-                    this.$refs.form.validate().then(valid => {
+                    this.$refs.form.validate().then(({ valid, errors }) => {
                         if (valid) {
                             this.save();
+                        } else {
+                            this.showSnack("{{ _('Please review the form for errors.')}}")
+                            const invalidFieldId = errors.find((e) => Boolean(e?.id))?.id
+                            scrollToElementById(invalidFieldId)
                         }
                     });
                 },

--- a/enferno/admin/templates/admin/locations.html
+++ b/enferno/admin/templates/admin/locations.html
@@ -547,9 +547,13 @@
                 },
                 
                 validateForm() {
-                    this.$refs.form.validate().then(valid => {
+                    this.$refs.form.validate().then(({ valid, errors }) => {
                         if (valid) {
                             this.save();
+                        } else {
+                            this.showSnack("{{ _('Please review the form for errors.')}}")
+                            const invalidFieldId = errors.find((e) => Boolean(e?.id))?.id
+                            scrollToElementById(invalidFieldId)
                         }
                     });
                 }

--- a/enferno/static/js/common/config.js
+++ b/enferno/static/js/common/config.js
@@ -5,6 +5,15 @@ const validationRules = {
     min: (v) => v.length >= 6 || 'Min 6 characters',
 };
 
+// Helper functions
+function scrollToElementById(elementId) {
+    const element = document.getElementById(elementId)
+    element?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center',
+    })
+}
+
 // global vuetify config object passed to most pages of the system
 const vuetifyConfig = {
     defaults: {


### PR DESCRIPTION
## Jira Issue
1. [1352](https://syriajustice.atlassian.net/browse/BYNT-1352)

## Description
On pages like Actors, Bulletins, Locations and Incidents, when adding or editing a new record, if there’s an invalid element auto scroll to the invalid element, this will make it easier for users to find the problem on the form

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] New strings prepared for translations

## API Changes (if applicable)
- [ ] Permissions checked
- [ ] Endpoint tests added

## Additional Notes
[Any other relevant information]
