### PR TITLE
Fix pagination after bulk updates on the bulletins page

### DIFF
--- a/enferno/admin/templates/admin/bulletins.html
+++ b/enferno/admin/templates/admin/bulletins.html
@@ -1083,7 +1083,7 @@
                                 // default refresh to first page
                                 this.options.page = 1;
 
-                                this.refresh(true);
+                                this.refresh();
                                 this.showSnack("{{ _('Bulk Update is finished!')}}")
                             } else {
                                 //console.log(this.jobs)


### PR DESCRIPTION
## Jira Issue
1. [1304](https://syriajustice.atlassian.net/browse/BYNT-1304)

## Description
This PR addresses an issue where the bulletins page refetches data with incorrect pagination after a bulk update, causing the table to display more items than initially selected (e.g., more than 10 records when set to show 10).

Steps to Reproduce:
Navigate to the bulletins page.
Ensure the database contains at least 11 records.
Set the table to display only 10 records per page.
Select multiple checkboxes and perform a bulk update.
After the bulk update is completed, observe that the page sends a request with page=undefined&per_page=undefined, resulting in the endpoint defaulting to per_page=30 and displaying more records than expected.

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] New strings prepared for translations

## API Changes (if applicable)
- [ ] Permissions checked
- [ ] Endpoint tests added

## Additional Notes
[Any other relevant information]
