### PR TITLE
Fix 'Invalid Date' in Import Log Dialog

### DIFF
--- a/enferno/data_import/templates/import-log.html
+++ b/enferno/data_import/templates/import-log.html
@@ -42,6 +42,10 @@
                                             ${localDate(item.created_at)}
                                         </template>
 
+                                        <template v-slot:item.imported_at="{item}">
+                                            ${localDate(item.imported_at)}
+                                        </template>
+
                                         <template v-slot:item.status="{item}">
                                           <import-log-status :item="item"></import-log-status>
                                         </template>

--- a/enferno/static/js/components/ImportLogCard.js
+++ b/enferno/static/js/components/ImportLogCard.js
@@ -2,10 +2,6 @@ const ImportLogCard = Vue.defineComponent({
   props: ['log'],
 
   mounted() {
-
-    //convert expiry to localized date
-    this.log.imported_at = this.localDate(this.log.imported_at);
-
     if (this.item?.id) {
       this.loadImportedItem();
     }


### PR DESCRIPTION
## Jira Issue
1. [1343](https://syriajustice.atlassian.net/browse/BYNT-1343)

## Description
On the Import Log page, after successfully importing an element, clicking on a row to display the import dialog shows "Invalid Date" instead of the correct imported_at date.

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] New strings prepared for translations

## API Changes (if applicable)
- [ ] Permissions checked
- [ ] Endpoint tests added

## Additional Notes
[Any other relevant information]
