### PR TITLE
Duplicated rows when creating records

### DIFF
--- a/enferno/admin/templates/admin/actors.html
+++ b/enferno/admin/templates/admin/actors.html
@@ -1582,8 +1582,8 @@
                         axios.post("/admin/api/actor/", {
                             item: this.editedItem
                         }).then(response => {
-                            this.items.push(this.editedItem);
-                            this.showSnack(response.data);
+                            this.items.push(response.data.data);
+                            this.showSnack(response.data.message);
                             this.refresh();
                             this.close();
                         }).catch(err => {

--- a/enferno/admin/templates/admin/bulletins.html
+++ b/enferno/admin/templates/admin/bulletins.html
@@ -1608,8 +1608,8 @@
                             axios.post("/admin/api/bulletin/", {
                                 item: this.editedItem
                             }).then(response => {
-                                this.items.push(this.editedItem);
-                                this.showSnack(response.data);
+                                this.items.push(response.data.data);
+                                this.showSnack(response.data.message);
                                 this.refresh();
                                 this.close();
                             }).catch(err => {

--- a/enferno/admin/templates/admin/eventtypes.html
+++ b/enferno/admin/templates/admin/eventtypes.html
@@ -306,12 +306,11 @@
                         })
 
                     } else {
-                        this.items.push(this.editedItem);
-
+                        
                         axios.post("/admin/api/eventtype/", {item: this.editedItem})
-                            .then(response => {
-
-                                this.showSnack(response.data);
+                        .then(response => {
+                                this.items.push(response.data.data);
+                                this.showSnack(response.data.message);
                                 this.refresh();
                                 this.close();
                             }).catch(err => {

--- a/enferno/admin/templates/admin/incidents.html
+++ b/enferno/admin/templates/admin/incidents.html
@@ -1466,8 +1466,8 @@
                         axios.post("/admin/api/incident/", {
                             item: this.editedItem
                         }).then(response => {
-                            this.items.push(this.editedItem);
-                            this.showSnack(response.data);
+                            this.items.push(response.data.data);
+                            this.showSnack(response.data.message);
                             this.refresh();
                             this.close();
                         }).catch(err => {

--- a/enferno/admin/templates/admin/labels.html
+++ b/enferno/admin/templates/admin/labels.html
@@ -379,11 +379,11 @@
                                 this.refresh()
                             })
                     } else {
-                        this.items.push(this.editedItem);
-
                         axios
                             .post("/admin/api/label/", {item: this.editedItem})
                             .then(response => {
+                                this.items.push(response.data.data);
+                                this.showSnack(response.data.message);
                                 this.showSnack(response.data);
                                 this.refresh()
                             });

--- a/enferno/admin/templates/admin/locations.html
+++ b/enferno/admin/templates/admin/locations.html
@@ -536,8 +536,8 @@
                         //create new record
                         axios.post("/admin/api/location/", {item: this.editedItem})
                             .then(response => {
-                                this.items.push(this.editedItem);
-                                this.showSnack(response.data);
+                                this.items.push(response.data.data);
+                                this.showSnack(response.data.message);
                                 this.refresh();
                                 this.close();
                             }).catch(err => {

--- a/enferno/admin/templates/admin/roles.html
+++ b/enferno/admin/templates/admin/roles.html
@@ -328,14 +328,12 @@
                                 this.refresh()
                                 this.close();
                             });
-                        } else {
-                        this.items.push(this.editedItem);
-
+                    } else {
                         axios
                             .post("/admin/api/role/", {item: this.editedItem})
                             .then(response => {
-
-                                this.showSnack(response.data);
+                                this.items.push(response.data.data);
+                                this.showSnack(response.data.message);
                                 this.refresh()
                                 this.close()
                             });

--- a/enferno/admin/templates/admin/sources.html
+++ b/enferno/admin/templates/admin/sources.html
@@ -332,8 +332,8 @@
                     } else {
                         //create new record
                         axios
-                        .post("/admin/api/source/", {item: this.editedItem})
-                        .then(response => {
+                            .post("/admin/api/source/", {item: this.editedItem})
+                            .then(response => {
                                 this.items.push(response.data.data);
                                 this.showSnack(response.data.message);
                                 this.refresh();

--- a/enferno/admin/templates/admin/sources.html
+++ b/enferno/admin/templates/admin/sources.html
@@ -330,12 +330,12 @@
                                 this.close();
                             })
                     } else {
-                        this.items.push(this.editedItem);
                         //create new record
                         axios
-                            .post("/admin/api/source/", {item: this.editedItem})
-                            .then(response => {
-                                this.showSnack(response.data);
+                        .post("/admin/api/source/", {item: this.editedItem})
+                        .then(response => {
+                                this.items.push(response.data.data);
+                                this.showSnack(response.data.message);
                                 this.refresh();
                                 this.close();
 

--- a/enferno/admin/views.py
+++ b/enferno/admin/views.py
@@ -325,7 +325,12 @@ def api_label_create(
         Activity.create(
             current_user, Activity.ACTION_CREATE, Activity.STATUS_SUCCESS, label.to_mini(), "label"
         )
-        return f"Created Label #{label.id}", 200
+
+        response = {
+            "message": f"Created Label #{label.id}",
+            "data": label.to_dict(),
+        }
+        return Response(json.dumps(response), content_type="application/json"), 200
     else:
         return "Save Failed", 417
 
@@ -471,7 +476,12 @@ def api_eventtype_create(
             eventtype.to_mini(),
             "eventtype",
         )
-        return f"Created Event #{eventtype.id}", 200
+
+        response = {
+            "message": f"Created Event #{eventtype.id}",
+            "data": eventtype.to_dict(),
+        }
+        return Response(json.dumps(response), content_type="application/json"), 200
     else:
         return "Save Failed", 417
 
@@ -906,7 +916,11 @@ def api_source_create(
             source.to_mini(),
             "source",
         )
-        return f"Created Source #{source.id}", 200
+        response = {
+            "message": f"Created Source #{source.id}",
+            "data": source.to_dict(),
+        }
+        return Response(json.dumps(response), content_type="application/json"), 200
     else:
         return "Save Failed", 417
 
@@ -1075,7 +1089,14 @@ def api_location_create(
             location.to_mini(),
             "location",
         )
-        return f"Created Location #{location.id}", 200
+
+        response = {
+            "message": f"Created Location #{location.id}",
+            "data": location.to_dict(),
+        }
+        return Response(json.dumps(response), content_type="application/json"), 200
+    else:
+        return "Error creating Location", 417
 
 
 @admin.put("/api/location/<int:id>")
@@ -2918,7 +2939,11 @@ def api_bulletin_create(
             "bulletin",
         )
 
-        return f"Created Bulletin #{bulletin.id}", 200
+        response = {
+            "message": f"Created Bulletin #{bulletin.id}",
+            "data": bulletin.to_dict(),
+        }
+        return Response(json.dumps(response), content_type="application/json"), 200
     else:
         return "Error creating Bulletin", 417
 
@@ -3877,7 +3902,12 @@ def api_actor_create(
         Activity.create(
             current_user, Activity.ACTION_CREATE, Activity.STATUS_SUCCESS, actor.to_mini(), "actor"
         )
-        return f"Created Actor #{actor.id}", 200
+
+        response = {
+            "message": f"Created Actor #{actor.id}",
+            "data": actor.to_dict(),
+        }
+        return Response(json.dumps(response), content_type="application/json"), 200
     else:
         return "Error creating Actor", 417
 
@@ -4803,8 +4833,12 @@ def api_role_create(
         Activity.create(
             current_user, Activity.ACTION_CREATE, Activity.STATUS_SUCCESS, role.to_mini(), "role"
         )
-        return "Created", 200
 
+        response = {
+            "message": f"Created Role #{role.id}",
+            "data": role.to_dict(),
+        }
+        return Response(json.dumps(response), content_type="application/json"), 200
     else:
         return "Save Failed", 417
 
@@ -4999,7 +5033,12 @@ def api_incident_create(
             incident.to_mini(),
             "incident",
         )
-        return f"Created Incident #{incident.id}", 200
+
+        response = {
+            "message": f"Created Incident #{incident.id}",
+            "data": incident.to_dict(),
+        }
+        return Response(json.dumps(response), content_type="application/json"), 200
     else:
         return "Error creating Incident", 417
 


### PR DESCRIPTION
## Jira Issue
1. [1353](https://syriajustice.atlassian.net/browse/BYNT-1353)

## Description
**Problem:**
Currently, when creating records on pages such as bulletins, actors, etc., the newly created item is pushed directly into the table without an ID. This causes occasional visual artifacts where the table displays duplicate rows.

**Solution:**
This PR resolves the issue by using the server response, which includes the correct ID, to update the table. This ensures the integrity of the data displayed and eliminates duplicate rows caused by the missing ID.

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] New strings prepared for translations

## API Changes (if applicable)
- [ ] Permissions checked
- [ ] Endpoint tests added

## Additional Notes
[Any other relevant information]
