### PR TITLE
Confirm related entities are consistently sorted by last update time

### DIFF
--- a/enferno/admin/models/Actor.py
+++ b/enferno/admin/models/Actor.py
@@ -94,16 +94,30 @@ class Actor(db.Model, BaseMixin):
     )
 
     # Actors that this actor relate to ->
-    actors_to = db.relationship("Atoa", backref="actor_from", foreign_keys="Atoa.actor_id")
+    actors_to = db.relationship(
+        "Atoa",
+        backref="actor_from",
+        foreign_keys="Atoa.actor_id",
+        order_by="Atoa.updated_at.desc()",
+    )
 
     # Actors that relate to this <-
-    actors_from = db.relationship("Atoa", backref="actor_to", foreign_keys="Atoa.related_actor_id")
+    actors_from = db.relationship(
+        "Atoa",
+        backref="actor_to",
+        foreign_keys="Atoa.related_actor_id",
+        order_by="Atoa.updated_at.desc()",
+    )
 
     # Related Bulletins
-    related_bulletins = db.relationship("Atob", backref="actor", foreign_keys="Atob.actor_id")
+    related_bulletins = db.relationship(
+        "Atob", backref="actor", foreign_keys="Atob.actor_id", order_by="Atob.updated_at.desc()"
+    )
 
     # Related Incidents
-    related_incidents = db.relationship("Itoa", backref="actor", foreign_keys="Itoa.actor_id")
+    related_incidents = db.relationship(
+        "Itoa", backref="actor", foreign_keys="Itoa.actor_id", order_by="Itoa.updated_at.desc()"
+    )
 
     type = db.Column(db.String(255))
     sex = db.Column(db.String(255))

--- a/enferno/admin/models/Bulletin.py
+++ b/enferno/admin/models/Bulletin.py
@@ -113,18 +113,36 @@ class Bulletin(db.Model, BaseMixin):
     )
 
     # Bulletins that this bulletin relate to ->
-    bulletins_to = db.relationship("Btob", backref="bulletin_from", foreign_keys="Btob.bulletin_id")
+    bulletins_to = db.relationship(
+        "Btob",
+        backref="bulletin_from",
+        foreign_keys="Btob.bulletin_id",
+        order_by="Btob.updated_at.desc()",
+    )
 
     # Bulletins that relate to this <-
     bulletins_from = db.relationship(
-        "Btob", backref="bulletin_to", foreign_keys="Btob.related_bulletin_id"
+        "Btob",
+        backref="bulletin_to",
+        foreign_keys="Btob.related_bulletin_id",
+        order_by="Btob.updated_at.desc()",
     )
 
     # Related Actors
-    related_actors = db.relationship("Atob", backref="bulletin", foreign_keys="Atob.bulletin_id")
+    related_actors = db.relationship(
+        "Atob",
+        backref="bulletin",
+        foreign_keys="Atob.bulletin_id",
+        order_by="Atob.updated_at.desc()",
+    )
 
     # Related Incidents
-    related_incidents = db.relationship("Itob", backref="bulletin", foreign_keys="Itob.bulletin_id")
+    related_incidents = db.relationship(
+        "Itob",
+        backref="bulletin",
+        foreign_keys="Itob.bulletin_id",
+        order_by="Itob.updated_at.desc()",
+    )
 
     publish_date = db.Column(db.DateTime, index=True)
     documentation_date = db.Column(db.DateTime, index=True)

--- a/enferno/admin/models/Incident.py
+++ b/enferno/admin/models/Incident.py
@@ -93,18 +93,36 @@ class Incident(db.Model, BaseMixin):
     )
 
     # Related Actors
-    related_actors = db.relationship("Itoa", backref="incident", foreign_keys="Itoa.incident_id")
+    related_actors = db.relationship(
+        "Itoa",
+        backref="incident",
+        foreign_keys="Itoa.incident_id",
+        order_by="Itoa.updated_at.desc()",
+    )
 
     # Related Bulletins
-    related_bulletins = db.relationship("Itob", backref="incident", foreign_keys="Itob.incident_id")
+    related_bulletins = db.relationship(
+        "Itob",
+        backref="incident",
+        foreign_keys="Itob.incident_id",
+        order_by="Itob.updated_at.desc()",
+    )
 
     # Related Incidents
     # Incidents that this incident relate to ->
-    incidents_to = db.relationship("Itoi", backref="incident_from", foreign_keys="Itoi.incident_id")
+    incidents_to = db.relationship(
+        "Itoi",
+        backref="incident_from",
+        foreign_keys="Itoi.incident_id",
+        order_by="Itoi.updated_at.desc()",
+    )
 
     # Incidents that relate to this <-
     incidents_from = db.relationship(
-        "Itoi", backref="incident_to", foreign_keys="Itoi.related_incident_id"
+        "Itoi",
+        backref="incident_to",
+        foreign_keys="Itoi.related_incident_id",
+        order_by="Itoi.updated_at.desc()",
     )
 
     status = db.Column(db.String(255))


### PR DESCRIPTION
## Jira Issue
https://syriajustice.atlassian.net/browse/BYNT-1305

## Description
This PR ensures that related entities (actors, bulletins, incidents) in all views are correctly sorted by most recently updated first, as specified in the model definitions using order_by="[Relation].updated_at.desc()".
