### PR TITLE
Media file is not fully visible after rotation

### DIFF
--- a/enferno/static/js/components/ImageViewer.js
+++ b/enferno/static/js/components/ImageViewer.js
@@ -1,89 +1,143 @@
 const ImageViewer = Vue.defineComponent({
-    props: ['media', 'mediaType'],
-    data: () => {
-      return {
-        translations: window.translations,
-        lg: {
-            inline: null,
-            fullscreen: null
-        },
-      };
-    },
+    props: ['media', 'mediaType', 'class'],
+    data: () => ({
+      translations: window.translations,
+      lg: {
+        inline: null,
+        fullscreen: null,
+      },
+    }),
     unmounted() {
-        this.destroyInlineLightbox();
-        this.destroyFullscreenLightbox();
+      this.destroyInlineLightbox();
+      this.destroyFullscreenLightbox();
     },
     methods: {
-        requestFullscreen(nextOptions) {
-            const el = this.$refs.imageViewer;
-            if (!el) return;
+      requestFullscreen(nextOptions) {
+        const el = this.$refs.imageViewer;
+        if (!el) return;
+  
+        const defaultOptions = {
+          plugins: [lgZoom, lgThumbnail, lgRotate],
+          download: false,
+          showZoomInOutIcons: true,
+          actualSize: false,
+          speed: 0,
+          selector: '.media-item',
+        };
+  
+        const options = { ...defaultOptions, ...nextOptions };
+  
+        this.lg.fullscreen = lightGallery(el, options);
+        this.lg.fullscreen.openGallery(0);
+  
+        // Add rotate event listener (same as inline)
+        this.addRotateListener(this.lg.fullscreen);
+  
+        this.lg.fullscreen.el.addEventListener('lgAfterClose', () => {
+          this.destroyFullscreenLightbox();
+        });
+      },
+      initInlineLightbox(nextOptions) {
+        const el = this.$refs.imageViewer;
+        if (!el) return;
+  
+        const defaultOptions = {
+          plugins: [lgZoom, lgThumbnail, lgRotate],
+          download: false,
+          showZoomInOutIcons: true,
+          actualSize: false,
+          speed: 0,
+          selector: '.media-item',
+          container: el,
+          closable: false,
+        };
+  
+        const options = { ...defaultOptions, ...nextOptions };
+  
+        this.lg.inline = lightGallery(el, options);
+        this.lg.inline.openGallery(0);
+  
+        // Add rotate event listener (same as fullscreen)
+        this.addRotateListener(this.lg.inline);
+      },
+      addRotateListener(lgInstance) {
+        if (!lgInstance || !lgInstance.el) return;
+      
+        // Listen for both rotate left and rotate right events
+        ['lgRotateLeft', 'lgRotateRight'].forEach(evtName => {
+          lgInstance.el.addEventListener(evtName, (evt) => {
+            const rotate = evt.detail.rotate; // Rotation angle in degrees (0, 90, 180, 270)
 
-            const defaultOptions = {
-                plugins: [lgZoom, lgThumbnail, lgRotate],
-                download: false,
-                showZoomInOutIcons: true,
-                actualSize: false,
-                speed: 0,
-                selector: '.media-item',
+            const c = evt.target.closest('.lg-outer');
+      
+            const container = lgInstance.el.querySelector('.lg-content');
+            const imgWrapper = lgInstance.el.querySelector('.lg-img-rotate');
+            const img = lgInstance.el.querySelector('img.lg-object');
+
+            if (!container || !imgWrapper || !img) return;
+      
+            const { width: containerW, height: containerH } = container.getBoundingClientRect();
+            const { naturalWidth: naturalW, naturalHeight: naturalH } = img;
+      
+            // Check if image is rotated by 90 or 270 degrees (dimensions swap)
+            const isRotated = rotate % 180 !== 0;
+            const imgW = isRotated ? naturalH : naturalW;
+            const imgH = isRotated ? naturalW : naturalH;
+      
+            // Calculate scale to fit the image inside the container
+            const scale = Math.min(containerW / imgW, containerH / imgH);
+
+            if (isRotated) {
+              // Apply scaled width and height, swapping due to rotation
+              imgWrapper.style.width = `${imgH * scale}px`;
+              imgWrapper.style.height = `${imgW * scale}px`;
+      
+              // Center the image wrapper inside the container
+              const leftMargin = (containerW - imgWrapper.offsetWidth) / 2;
+              const topMargin = (containerH - imgWrapper.offsetHeight) / 2;
+      
+              imgWrapper.style.marginLeft = `${leftMargin}px`;
+              imgWrapper.style.marginTop = `${topMargin}px`;
+            } else {
+              // Reset styles when image is not rotated
+              ['width', 'height', 'marginLeft', 'marginTop'].forEach(prop => {
+                imgWrapper.style[prop] = null;
+              });
             }
-
-            const options = { ...defaultOptions, ...nextOptions }
-        
-            this.lg.fullscreen = lightGallery(el, options);
-            this.lg.fullscreen.openGallery(0); // Open the first image by default
-
-            // Add an event listener to destroy the fullscreen lightbox on close
-            this.lg.fullscreen.el.addEventListener('lgAfterClose', () => {
-                this.destroyFullscreenLightbox();
-            });
-        },
-        initInlineLightbox(nextOptions) {
-            const el = this.$refs.imageViewer;
-            if (!el) return;
-
-            const defaultOptions = {
-                plugins: [lgZoom, lgThumbnail, lgRotate],
-                download: false,
-                showZoomInOutIcons: true,
-                actualSize: false,
-                speed: 0,
-                selector: '.media-item',
-                container: el,
-                closable: false,
-            }
-
-            const options = { ...defaultOptions, ...nextOptions }
-        
-            this.lg.inline = lightGallery(el, options);
-            this.lg.inline.openGallery(0); // Open the first image by default
-        },
-        destroyInlineLightbox() {
-            this.lg.inline?.destroy();
-            this.lg.inline = null;
-        },
-        destroyFullscreenLightbox() {
-            this.lg.fullscreen?.destroy();
-            this.lg.fullscreen = null;
-        },
+      
+            // Remove any max size constraints on the image itself
+            img.style.maxWidth = '';
+            img.style.maxHeight = '';
+          });
+        });
+      },      
+      destroyInlineLightbox() {
+        this.lg.inline?.destroy();
+        this.lg.inline = null;
+      },
+      destroyFullscreenLightbox() {
+        this.lg.fullscreen?.destroy();
+        this.lg.fullscreen = null;
+      },
     },
     watch: {
-        media: {
-          deep: true,
-          immediate: true,
-          handler() {
-            this.$nextTick(() => {
-              this.destroyInlineLightbox();
-              this.initInlineLightbox(); // re-init with latest DOM
-            });
-          }
+      media: {
+        deep: true,
+        immediate: true,
+        handler() {
+          this.$nextTick(() => {
+            this.destroyInlineLightbox();
+            this.initInlineLightbox();
+          });
         }
+      }
     },
     template: `
-        <div ref="imageViewer">
-            <a class="media-item h-100 block" :data-src="media.s3url">
-                <img :src="media.s3url" class="w-100 h-100 bg-black" style="object-fit: contain;"></img>
-            </a>
-        </div>
-      `,
+      <div ref="imageViewer" class="class">
+        <a class="media-item h-100 block" :data-src="media.s3url">
+          <img :src="media.s3url" class="w-100 h-100 bg-black" style="object-fit: contain;" />
+        </a>
+      </div>
+    `,
   });
   

--- a/enferno/static/js/components/ImageViewer.js
+++ b/enferno/static/js/components/ImageViewer.js
@@ -1,5 +1,5 @@
 const ImageViewer = Vue.defineComponent({
-    props: ['media', 'mediaType', 'class'],
+    props: ['media', 'mediaType'],
     data: () => ({
       translations: window.translations,
       lg: {
@@ -68,11 +68,9 @@ const ImageViewer = Vue.defineComponent({
           lgInstance.el.addEventListener(evtName, (evt) => {
             const rotate = evt.detail.rotate; // Rotation angle in degrees (0, 90, 180, 270)
 
-            const c = evt.target.closest('.lg-outer');
-      
-            const container = lgInstance.el.querySelector('.lg-content');
-            const imgWrapper = lgInstance.el.querySelector('.lg-img-rotate');
-            const img = lgInstance.el.querySelector('img.lg-object');
+            const container = lgInstance.$content.firstElement;
+            const imgWrapper = container.querySelector('.lg-img-rotate');
+            const img = container.querySelector('img.lg-object');
 
             if (!container || !imgWrapper || !img) return;
       
@@ -133,7 +131,7 @@ const ImageViewer = Vue.defineComponent({
       }
     },
     template: `
-      <div ref="imageViewer" class="class">
+      <div ref="imageViewer">
         <a class="media-item h-100 block" :data-src="media.s3url">
           <img :src="media.s3url" class="w-100 h-100 bg-black" style="object-fit: contain;" />
         </a>

--- a/enferno/static/js/components/ImageViewer.js
+++ b/enferno/static/js/components/ImageViewer.js
@@ -39,8 +39,8 @@ const ImageViewer = Vue.defineComponent({
 
             // When the user rotates the image, it may overflow the preview container.
             // This is a workaround to force the image to fit within the container.
-            this.addRotateListener(this.lg.inline);
-            this.setupZoomHack(this.lg.inline);
+            this.addRotateListener(this.lg.fullscreen);
+            this.setupZoomHack(this.lg.fullscreen);
         },
         initInlineLightbox(nextOptions) {
             const el = this.$refs.imageViewer;

--- a/enferno/static/js/components/ImageViewer.js
+++ b/enferno/static/js/components/ImageViewer.js
@@ -1,157 +1,161 @@
 const ImageViewer = Vue.defineComponent({
     props: ['media', 'mediaType'],
-    data: () => ({
-      translations: window.translations,
-      lg: {
-        inline: null,
-        fullscreen: null,
-      },
-    }),
+    data: () => {
+      return {
+        translations: window.translations,
+        lg: {
+            inline: null,
+            fullscreen: null
+        },
+      };
+    },
     unmounted() {
-      this.destroyInlineLightbox();
-      this.destroyFullscreenLightbox();
+        this.destroyInlineLightbox();
+        this.destroyFullscreenLightbox();
     },
     methods: {
-      requestFullscreen(nextOptions) {
-        const el = this.$refs.imageViewer;
-        if (!el) return;
+        requestFullscreen(nextOptions) {
+            const el = this.$refs.imageViewer;
+            if (!el) return;
 
-        const defaultOptions = {
-          plugins: [lgZoom, lgThumbnail, lgRotate],
-          download: false,
-          showZoomInOutIcons: true,
-          actualSize: false,
-          speed: 0,
-          selector: '.media-item',
-        };
-
-        const options = { ...defaultOptions, ...nextOptions };
-
-        this.lg.fullscreen = lightGallery(el, options);
-        this.lg.fullscreen.openGallery(0);
-
-        this.lg.fullscreen.el.addEventListener('lgAfterClose', () => {
-          this.destroyFullscreenLightbox();
-        });
-
-        // When the user rotates the image, it may overflow the preview container.
-        // This is a workaround to force the image to fit within the container.
-        this.addRotateListener(this.lg.fullscreen);
-        this.setupZoomHack(this.lg.fullscreen);
-      },
-      initInlineLightbox(nextOptions) {
-        const el = this.$refs.imageViewer;
-        if (!el) return;
-
-        const defaultOptions = {
-          plugins: [lgZoom, lgThumbnail, lgRotate],
-          download: false,
-          showZoomInOutIcons: true,
-          actualSize: false,
-          speed: 0,
-          selector: '.media-item',
-          container: el,
-          closable: false,
-        };
-
-        const options = { ...defaultOptions, ...nextOptions };
-
-        this.lg.inline = lightGallery(el, options);
-        this.lg.inline.openGallery(0);
-
-        // When the user rotates the image, it may overflow the preview container.
-        // This is a workaround to force the image to fit within the container.
-        this.addRotateListener(this.lg.inline);
-        this.setupZoomHack(this.lg.inline);
-      },
-      addRotateListener(lgInstance) {
-        if (!lgInstance?.el) return;
-
-        ['lgRotateLeft', 'lgRotateRight'].forEach(evtName => {
-          lgInstance.el.addEventListener(evtName, (evt) => {
-            const rotate = evt.detail.rotate;
-
-            const container = lgInstance.$content.firstElement;
-            const imgWrapper = container.querySelector('.lg-img-rotate');
-            const img = container.querySelector('img.lg-object');
-
-            if (!container || !imgWrapper || !img) return;
-
-            const { width: containerW, height: containerH } = container.getBoundingClientRect();
-            const { naturalWidth: naturalW, naturalHeight: naturalH } = img;
-
-            const isRotated = rotate % 180 !== 0;
-            const imgW = isRotated ? naturalH : naturalW;
-            const imgH = isRotated ? naturalW : naturalH;
-
-            const scale = Math.min(containerW / imgW, containerH / imgH);
-
-            // Image gets rotated, so we flip width/height
-            if (isRotated) {
-              imgWrapper.style.width = `${imgH * scale}px`;
-              imgWrapper.style.height = `${imgW * scale}px`;
-
-              const leftMargin = (containerW - imgWrapper.offsetWidth) / 2;
-              const topMargin = (containerH - imgWrapper.offsetHeight) / 2;
-
-              imgWrapper.style.marginLeft = `${leftMargin}px`;
-              imgWrapper.style.marginTop = `${topMargin}px`;
-            } else {
-              // Reset any rotation-related dimensions
-              ['width', 'height', 'marginLeft', 'marginTop'].forEach(prop => {
-                imgWrapper.style[prop] = null;
-              });
+            const defaultOptions = {
+                plugins: [lgZoom, lgThumbnail, lgRotate],
+                download: false,
+                showZoomInOutIcons: true,
+                actualSize: false,
+                speed: 0,
+                selector: '.media-item',
             }
 
-            img.style.maxWidth = '';
-            img.style.maxHeight = '';
+            const options = { ...defaultOptions, ...nextOptions }
+        
+            this.lg.fullscreen = lightGallery(el, options);
+            this.lg.fullscreen.openGallery(0); // Open the first image by default
+
+            // Add an event listener to destroy the fullscreen lightbox on close
+            this.lg.fullscreen.el.addEventListener('lgAfterClose', () => {
+                this.destroyFullscreenLightbox();
+            });
+
+            // When the user rotates the image, it may overflow the preview container.
+            // This is a workaround to force the image to fit within the container.
+            this.addRotateListener(this.lg.inline);
+            this.setupZoomHack(this.lg.inline);
+        },
+        initInlineLightbox(nextOptions) {
+            const el = this.$refs.imageViewer;
+            if (!el) return;
+
+            const defaultOptions = {
+                plugins: [lgZoom, lgThumbnail, lgRotate],
+                download: false,
+                showZoomInOutIcons: true,
+                actualSize: false,
+                speed: 0,
+                selector: '.media-item',
+                container: el,
+                closable: false,
+            }
+
+            const options = { ...defaultOptions, ...nextOptions }
+        
+            this.lg.inline = lightGallery(el, options);
+            this.lg.inline.openGallery(0); // Open the first image by default
+
+            // When the user rotates the image, it may overflow the preview container.
+            // This is a workaround to force the image to fit within the container.
+            this.addRotateListener(this.lg.inline);
+            this.setupZoomHack(this.lg.inline);
+        },
+        addRotateListener(lgInstance) {
+          if (!lgInstance?.el) return;
+  
+          ['lgRotateLeft', 'lgRotateRight'].forEach(evtName => {
+            lgInstance.el.addEventListener(evtName, (evt) => {
+              const rotate = evt.detail.rotate;
+  
+              const container = lgInstance.$content.firstElement;
+              const imgWrapper = container.querySelector('.lg-img-rotate');
+              const img = container.querySelector('img.lg-object');
+  
+              if (!container || !imgWrapper || !img) return;
+  
+              const { width: containerW, height: containerH } = container.getBoundingClientRect();
+              const { naturalWidth: naturalW, naturalHeight: naturalH } = img;
+  
+              const isRotated = rotate % 180 !== 0;
+              const imgW = isRotated ? naturalH : naturalW;
+              const imgH = isRotated ? naturalW : naturalH;
+  
+              const scale = Math.min(containerW / imgW, containerH / imgH);
+  
+              // Image gets rotated, so we flip width/height
+              if (isRotated) {
+                imgWrapper.style.width = `${imgH * scale}px`;
+                imgWrapper.style.height = `${imgW * scale}px`;
+  
+                const leftMargin = (containerW - imgWrapper.offsetWidth) / 2;
+                const topMargin = (containerH - imgWrapper.offsetHeight) / 2;
+  
+                imgWrapper.style.marginLeft = `${leftMargin}px`;
+                imgWrapper.style.marginTop = `${topMargin}px`;
+              } else {
+                // Reset any rotation-related dimensions
+                ['width', 'height', 'marginLeft', 'marginTop'].forEach(prop => {
+                  imgWrapper.style[prop] = null;
+                });
+              }
+  
+              img.style.maxWidth = '';
+              img.style.maxHeight = '';
+            });
           });
-        });
-      },
-      // HACK: Flip twice to fix zoom-drag not working after zoom in via button
-      forceEnableDrag(lgInstance) {
-        const flipBtn = lgInstance.$toolbar?.firstElement?.querySelector('#lg-flip-hor');
-        if (flipBtn) {
-          flipBtn.click();
-          flipBtn.click();
-        }
-      },
-      // Setup event listeners on zoom buttons to trigger drag fix
-      setupZoomHack(lgInstance) {
-        const zoomInBtn = lgInstance.$toolbar?.firstElement?.querySelector('.lg-zoom-in');
-        const zoomOutBtn = lgInstance.$toolbar?.firstElement?.querySelector('.lg-zoom-out');
+        },
+        // HACK: Flip twice to fix zoom-drag not working after zoom in via button
+        forceEnableDrag(lgInstance) {
+          const flipBtn = lgInstance.$toolbar?.firstElement?.querySelector('#lg-flip-hor');
+          if (flipBtn) {
+            flipBtn.click();
+            flipBtn.click();
+          }
+        },
+        // Setup event listeners on zoom buttons to trigger drag fix
+        setupZoomHack(lgInstance) {
+          const zoomInBtn = lgInstance.$toolbar?.firstElement?.querySelector('.lg-zoom-in');
+          const zoomOutBtn = lgInstance.$toolbar?.firstElement?.querySelector('.lg-zoom-out');
 
-        const handler = () => this.forceEnableDrag(lgInstance);
+          const handler = () => this.forceEnableDrag(lgInstance);
 
-        zoomInBtn?.addEventListener('click', handler);
-        zoomOutBtn?.addEventListener('click', handler);
-      },
-      destroyInlineLightbox() {
-        this.lg.inline?.destroy();
-        this.lg.inline = null;
-      },
-      destroyFullscreenLightbox() {
-        this.lg.fullscreen?.destroy();
-        this.lg.fullscreen = null;
-      },
+          zoomInBtn?.addEventListener('click', handler);
+          zoomOutBtn?.addEventListener('click', handler);
+        },
+        destroyInlineLightbox() {
+            this.lg.inline?.destroy();
+            this.lg.inline = null;
+        },
+        destroyFullscreenLightbox() {
+            this.lg.fullscreen?.destroy();
+            this.lg.fullscreen = null;
+        },
     },
     watch: {
-      media: {
-        deep: true,
-        immediate: true,
-        handler() {
-          this.$nextTick(() => {
-            this.destroyInlineLightbox();
-            this.initInlineLightbox();
-          });
+        media: {
+          deep: true,
+          immediate: true,
+          handler() {
+            this.$nextTick(() => {
+              this.destroyInlineLightbox();
+              this.initInlineLightbox(); // re-init with latest DOM
+            });
+          }
         }
-      }
     },
     template: `
-      <div ref="imageViewer">
-        <a class="media-item h-100 block" :data-src="media.s3url">
-          <img :src="media.s3url" class="w-100 h-100 bg-black" style="object-fit: contain;" />
-        </a>
-      </div>
-    `,
+        <div ref="imageViewer">
+            <a class="media-item h-100 block" :data-src="media.s3url">
+                <img :src="media.s3url" class="w-100 h-100 bg-black" style="object-fit: contain;"></img>
+            </a>
+        </div>
+      `,
   });
+  


### PR DESCRIPTION
## Jira Issue
1. [BYNT-1410](https://syriajustice.atlassian.net/browse/BYNT-1410)

## Description
When an image file originally saved in landscape orientation is rotated, it is not fully visible within the display frame. Part of the image is cropped or hidden after rotation, which affects usability and viewing experience.

THE FIX IN THIS PR is a workaround since lightgallery.js does not seem to support adjusting the image to fit after rotation, theres an open [issue](https://github.com/sachinchoolur/lightGallery/issues/1171) about it but they never implemented the fix

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] New strings prepared for translations

## API Changes (if applicable)
- [ ] Permissions checked
- [ ] Endpoint tests added

## Additional Notes
[Any other relevant information]


[BYNT-1410]: https://syriajustice.atlassian.net/browse/BYNT-1410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ