### PR TITLE
Update uwsgi.ini for UV virtual environment

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -1,5 +1,5 @@
 [uwsgi]
-virtualenv=env
+virtualenv=.venv
 module=run:app
 master=true
 processes=1


### PR DESCRIPTION
  ## Summary
  - Update `uwsgi.ini` virtualenv path from `env` to `.venv` to align with UV migration
  - Fixes deployment issues where UWSGI can't find Python environment after UV migration

  ## Background
  The recent UV migration changed the virtual environment location from `env/` to `.venv/`, but `uwsgi.ini` still referenced the old path, causing service startup failures.

  ## Changes
  - Updated `virtualenv=env` to `virtualenv=.venv` in `uwsgi.ini`
