### PR TITLE
Fix test failures after AI dependencies installation

### DIFF
--- a/enferno/settings.py
+++ b/enferno/settings.py
@@ -577,8 +577,8 @@ class TestConfig:
     NOTIFICATIONS = NOTIFICATIONS_DEFAULT_CONFIG
 
     # Dependencies (from dep_utils)
-    HAS_WHISPER = False  # Hardcoded for tests
-    HAS_TESSERACT = False  # Hardcoded for tests
+    HAS_WHISPER = dep_utils.has_whisper  # Use actual dependency detection
+    HAS_TESSERACT = dep_utils.has_tesseract  # Use actual dependency detection
 
     # Setup & System
     SETUP_COMPLETE = True  # Mark as complete to bypass setup wizard in tests

--- a/tests/admin/test_users.py
+++ b/tests/admin/test_users.py
@@ -27,6 +27,17 @@ from tests.models.admin import (
 
 @pytest.fixture(scope="function")
 def clean_slate_users(session):
+    from enferno.extensions import rds
+
+    # Clear Redis security keys to prevent persistence between tests
+    try:
+        keys_pattern = "security:user:*"
+        keys = rds.keys(keys_pattern)
+        if keys:
+            rds.delete(*keys)
+    except Exception:
+        pass  # Redis might not be available in some test environments
+
     session.query(Activity).delete(synchronize_session=False)
     session.query(Notification).delete(synchronize_session=False)
     session.query(User).delete(synchronize_session=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -264,9 +264,18 @@ def users(session):
 def uninitialized_users(session_uninitialized):
     """Create users for testing."""
     from enferno.user.models import User, Role
+    from tests.factories import UserFactory
 
     session = session_uninitialized
     admin_user = User.query.filter(User.roles.any(Role.name == "Admin")).first()
+    if not admin_user:
+        # Create admin user for setup wizard tests
+        admin_role = Role.query.filter_by(name="Admin").first()
+        admin_user = UserFactory()
+        admin_user.username = "testAdmin"
+        admin_user.roles.append(admin_role)
+        session.add(admin_user)
+        session.commit()
     yield admin_user
 
 


### PR DESCRIPTION
  **Problem**: Installing optional AI dependencies (`uv sync --extra ai`) caused 6 test failures due to hardcoded test configuration and state pollution.

  **Root Causes**:
  - Test config hardcoded `HAS_WHISPER = False` while deps were actually installed
  - Redis security keys persisted between tests causing "already requested" errors
  - Setup wizard tests missing admin user for authentication

  **Solution**:
  - Use dynamic dependency detection in tests instead of hardcoded values
  - Add Redis cleanup to prevent cross-test state pollution
  - Create admin user in uninitialized test fixtures

  **Result**: All 764 tests now pass with or without AI dependencies installed.
