### PR TITLE
Date format inconsistency

### DIFF
--- a/enferno/static/js/components/PopDateField.js
+++ b/enferno/static/js/components/PopDateField.js
@@ -17,6 +17,6 @@ const PopDateField = {
     }
   },
   template: `
-    <v-date-input :placeholder="$root.dateFormats.standardDate" :display-format="(date) => $root.formatDate(date, $root.dateFormats.standardDate)" class="flex-fill" :label="label" v-bind="$attrs" :rules="[$root.rules.dateValidation]" variant="outlined" hide-actions v-model="date" @click:clear="$emit('update:modelValue', null)" clearable></v-date-input>
+    <v-date-input :placeholder="$root.dateFormats.standardDate" :display-format="(date) => $root.formatDate(date, $root.dateFormats.standardDate)" :input-format="$root.dateFormats.standardDate" class="flex-fill" :label="label" v-bind="$attrs" :rules="[$root.rules.dateValidation]" variant="outlined" hide-actions v-model="date" @click:clear="$emit('update:modelValue', null)" clearable></v-date-input>
   `
 };

--- a/enferno/static/js/components/PopDateRangeField.js
+++ b/enferno/static/js/components/PopDateRangeField.js
@@ -29,6 +29,6 @@ const PopDateRangeField = {
   },
 
   template: `
-    <v-date-input :placeholder="$root.dateFormats.standardDate" :display-format="(date) => $root.formatDate(date, $root.dateFormats.standardDate)" v-bind="$attrs" multiple="range" :label="label" variant="outlined" v-model="dates" @click:clear="$emit('update:modelValue', [])" clearable></v-date-input>
+    <v-date-input :placeholder="$root.dateFormats.standardDate + ' - ' + $root.dateFormats.standardDate" :display-format="(date) => $root.formatDate(date, $root.dateFormats.standardDate)" :input-format="$root.dateFormats.standardDate" v-bind="$attrs" multiple="range" :label="label" variant="outlined" v-model="dates" @click:clear="$emit('update:modelValue', [])" clearable></v-date-input>
   `
 };


### PR DESCRIPTION
## Jira Issue
1. [BYNT-1448](https://syriajustice.atlassian.net/browse/BYNT-1448)

## Description
The date field format was updated to DD/MM/YYYY to be consistent across the database (I think). However, when entering dates manually, the system still requires the MM/DD/YYYY format.

This causes incorrect interpretations of entered dates. For example:

If the DA enters 3/5/2025 (expecting 3rd May 2025), the system interprets it as 5th March 2025 and displays it as 5/3/2025.

If the DA enters a date that cannot be flipped, e.g. 20/5/2025, the system rejects it, since it cannot interpret 20 as a month.

Display format: DD/MM/YYYY
Manual input requirement: MM/DD/YYYY

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] New strings prepared for translations

## API Changes (if applicable)
- [ ] Permissions checked
- [ ] Endpoint tests added

## Additional Notes
[Any other relevant information]
