### PR TITLE
Related Items View Not Loading Correctly

### DIFF
--- a/enferno/admin/templates/admin/actors.html
+++ b/enferno/admin/templates/admin/actors.html
@@ -772,17 +772,10 @@
 
             methods: {
                 handleRoute({ initialLoad = false } = {}) {
-                    // Use URLSearchParams to reliably read query strings on initial page load 
-                    const params = new URLSearchParams(window.location.search);
-                    const id = this.$route.params.id;
-                    const reltob = params.get('reltob');
-                    const reltoa = params.get('reltoa');
-                    const reltoi = params.get('reltoi');
-
-                    if (id) this.showActor(id);
-                    if (reltob) return this.filter_related_to_bulletin(reltob);
-                    if (reltoa) return this.filter_related_to_actor(reltoa);
-                    if (reltoi) return this.filter_related_to_incident(reltoi);
+                    if (this.$route.params.id) this.showActor(this.$route.params.id);
+                    if (this.$route.query.reltob) return this.filter_related_to_bulletin(this.$route.query.reltob);
+                    if (this.$route.query.reltoa) return this.filter_related_to_actor(this.$route.query.reltoa);
+                    if (this.$route.query.reltoi) return this.filter_related_to_incident(this.$route.query.reltoi);
 
                     // Only refresh on initial page load
                     if (initialLoad) this.refresh();
@@ -1714,8 +1707,10 @@
         app.component('mp-card', MPCard);
         app.component('vue-dropzone', VueDropzone);
 
-
-        app.use(router).use(vuetify).mount('#app');
-        window.app = app;
+        app.use(router).use(vuetify);
+        router.isReady().then(() => {
+            app.mount('#app');
+            window.app = app;
+        });
     </script>
 {% endblock %}

--- a/enferno/admin/templates/admin/actors.html
+++ b/enferno/admin/templates/admin/actors.html
@@ -743,7 +743,6 @@
                 },
             },
             mounted: function () {
-
                 // populate roles for advanced search for admins
                 {% if current_user.has_role('Admin') %}
                     api.get('/admin/api/roles/').then(res => {
@@ -753,9 +752,6 @@
                         console.log(e.message);
                     });
                 {% endif  %}
-
-                // Load initial data
-                this.refresh();
 
                 // display confirmation alert if edit dialog is open.
                 let self = this;
@@ -768,48 +764,29 @@
                     }
                 });
 
-
-                if (this.$route.params.id) {
-                    this.showActor(this.$route.params.id);
-                }
-
-                if (this.$route.query.reltob) {
-                    this.filter_related_to_bulletin(this.$route.query.reltob);
-                }
-
-                if (this.$route.query.reltoa) {
-                    this.filter_related_to_actor(this.$route.query.reltoa);
-                }
-
-                if (this.$route.query.reltoi) {
-                    this.filter_related_to_incident(this.$route.query.reltoi);
-                }
-
-                this.$router.afterEach((to, from) => {
-
-                    if (this.$route.query.reltob) {
-                        this.filter_related_to_bulletin(this.$route.query.reltob);
-                    }
-
-                    if (this.$route.query.reltoa) {
-                        this.filter_related_to_actor(this.$route.query.reltoa);
-                    }
-
-                    if (this.$route.query.reltoi) {
-                        this.filter_related_to_incident(this.$route.query.reltoi);
-                    }
-
-
-                    if (this.$route.params.id) {
-                        this.showActor(this.$route.params.id);
-                    }
-
-                })
-
-
+                this.handleRoute({ initialLoad: true });
+                this.$router.afterEach(() => {
+                    this.handleRoute();
+                });
             },
 
             methods: {
+                handleRoute({ initialLoad = false } = {}) {
+                    // Use URLSearchParams to reliably read query strings on initial page load 
+                    const params = new URLSearchParams(window.location.search);
+                    const id = this.$route.params.id;
+                    const reltob = params.get('reltob');
+                    const reltoa = params.get('reltoa');
+                    const reltoi = params.get('reltoi');
+
+                    if (id) this.showActor(id);
+                    if (reltob) return this.filter_related_to_bulletin(reltob);
+                    if (reltoa) return this.filter_related_to_actor(reltoa);
+                    if (reltoi) return this.filter_related_to_incident(reltoi);
+
+                    // Only refresh on initial page load
+                    if (initialLoad) this.refresh();
+                },
                 fetchIdNumberTypes() {
                     // If already loaded the exit
                     if (this.idNumberTypes.length) return

--- a/enferno/admin/templates/admin/bulletins.html
+++ b/enferno/admin/templates/admin/bulletins.html
@@ -851,7 +851,6 @@
 
                 },
                 mounted: function () {
-
                     // populate roles for advanced search for admins
                     {% if current_user.has_role('Admin') %}
                         api.get('/admin/api/roles/').then(res => {
@@ -861,9 +860,6 @@
                             console.error(e.message);
                         });
                     {% endif  %}
-                    
-                    // Load initial data
-                    this.refresh();
 
                     // display confirmation alert if edit dialog is open.
                     let self = this;
@@ -876,52 +872,29 @@
                         }
                     });
 
-
-                    if (this.$route.params.id) {
-                        this.showBulletin(this.$route.params.id);
-                    }
-
-                    if (this.$route.query.reltob) {
-                        this.filter_related_to_bulletin(this.$route.query.reltob);
-
-                    }
-
-                    if (this.$route.query.reltoa) {
-                        this.filter_related_to_actor(this.$route.query.reltoa);
-                    }
-
-                    if (this.$route.query.reltoi) {
-                        this.filter_related_to_incident(this.$route.query.reltoi);
-                    }
-
-
-                    this.$router.afterEach((to, from) => {
-
-
-                        if (this.$route.query.reltob) {
-                            this.filter_related_to_bulletin(this.$route.query.reltob);
-                        }
-
-                        if (this.$route.query.reltoa) {
-                            this.filter_related_to_actor(this.$route.query.reltoa);
-                        }
-
-                        if (this.$route.query.reltoi) {
-                            this.filter_related_to_incident(this.$route.query.reltoi);
-                        }
-
-
-                        if (this.$route.params.id) {
-
-                            this.showBulletin(this.$route.params.id);
-                        } else {
-                            this.bulletinDrawer = false;
-                        }
-
-                    })
+                    this.handleRoute({ initialLoad: true });
+                    this.$router.afterEach(() => {
+                        this.handleRoute();
+                    });
                 },
 
                 methods: {
+                    handleRoute({ initialLoad = false } = {}) {
+                        // Use URLSearchParams to reliably read query strings on initial page load 
+                        const params = new URLSearchParams(window.location.search);
+                        const id = this.$route.params.id;
+                        const reltob = params.get('reltob');
+                        const reltoa = params.get('reltoa');
+                        const reltoi = params.get('reltoi');
+
+                        if (id) this.showBulletin(id);
+                        if (reltob) return this.filter_related_to_bulletin(reltob);
+                        if (reltoa) return this.filter_related_to_actor(reltoa);
+                        if (reltoi) return this.filter_related_to_incident(reltoi);
+
+                        // Only refresh on initial page load
+                        if (initialLoad) this.refresh();
+                    },
                     validateForm() {
                         this.$refs.form.validate().then(({ valid, errors }) => {
                             if (valid) {

--- a/enferno/admin/templates/admin/bulletins.html
+++ b/enferno/admin/templates/admin/bulletins.html
@@ -880,17 +880,10 @@
 
                 methods: {
                     handleRoute({ initialLoad = false } = {}) {
-                        // Use URLSearchParams to reliably read query strings on initial page load 
-                        const params = new URLSearchParams(window.location.search);
-                        const id = this.$route.params.id;
-                        const reltob = params.get('reltob');
-                        const reltoa = params.get('reltoa');
-                        const reltoi = params.get('reltoi');
-
-                        if (id) this.showBulletin(id);
-                        if (reltob) return this.filter_related_to_bulletin(reltob);
-                        if (reltoa) return this.filter_related_to_actor(reltoa);
-                        if (reltoi) return this.filter_related_to_incident(reltoi);
+                        if (this.$route.params.id) this.showBulletin(this.$route.params.id);
+                        if (this.$route.query.reltob) return this.filter_related_to_bulletin(this.$route.query.reltob);
+                        if (this.$route.query.reltoa) return this.filter_related_to_actor(this.$route.query.reltoa);
+                        if (this.$route.query.reltoi) return this.filter_related_to_incident(this.$route.query.reltoi);
 
                         // Only refresh on initial page load
                         if (initialLoad) this.refresh();
@@ -1757,9 +1750,10 @@
         app.component('IdNumberDynamicField', IdNumberDynamicField);
         app.component('EventsSection', EventsSection);
 
-        app.use(router);
-        app.use(vuetify).mount('#app');
-
-        window.app = app;
+        app.use(router).use(vuetify);
+        router.isReady().then(() => {
+            app.mount('#app');
+            window.app = app;
+        });
     </script>
 {% endblock %}

--- a/enferno/admin/templates/admin/incidents.html
+++ b/enferno/admin/templates/admin/incidents.html
@@ -687,7 +687,6 @@
 
             },
             mounted: function () {
-
                 // populate roles for advanced search for admins
                 {% if current_user.has_role('Admin') %}
                     api.get('/admin/api/roles/').then(res => {
@@ -697,9 +696,6 @@
                         console.log(e.message);
                     });
                 {% endif  %}
-
-                // Load initial data
-                this.refresh();
 
                 // display confirmation alert if edit dialog is open.
                 let self = this;
@@ -712,48 +708,29 @@
                     }
                 });
 
-
-                if (this.$route.params.id) {
-                    this.showIncident(this.$route.params.id);
-                }
-
-                if (this.$route.query.reltob) {
-                    this.filter_related_to_bulletin(this.$route.query.reltob);
-                }
-
-                if (this.$route.query.reltoa) {
-                    this.filter_related_to_actor(this.$route.query.reltoa);
-                }
-
-                if (this.$route.query.reltoi) {
-                    this.filter_related_to_incident(this.$route.query.reltoi);
-                }
-
-                this.$router.afterEach((to, from, next) => {
-
-                    if (this.$route.query.reltob) {
-                        this.filter_related_to_bulletin(this.$route.query.reltob);
-                    }
-
-                    if (this.$route.query.reltoa) {
-                        this.filter_related_to_actor(this.$route.query.reltoa);
-                    }
-
-                    if (this.$route.query.reltoi) {
-                        this.filter_related_to_incident(this.$route.query.reltoi);
-                    }
-
-
-                    if (this.$route.params.id) {
-                        this.showIncident(this.$route.params.id);
-                    }
-
-                })
-
-
+                this.handleRoute({ initialLoad: true });
+                this.$router.afterEach(() => {
+                    this.handleRoute();
+                });
             },
 
             methods: {
+                handleRoute({ initialLoad = false } = {}) {
+                    // Use URLSearchParams to reliably read query strings on initial page load 
+                    const params = new URLSearchParams(window.location.search);
+                    const id = this.$route.params.id;
+                    const reltob = params.get('reltob');
+                    const reltoa = params.get('reltoa');
+                    const reltoi = params.get('reltoi');
+
+                    if (id) this.showIncident(id);
+                    if (reltob) return this.filter_related_to_bulletin(reltob);
+                    if (reltoa) return this.filter_related_to_actor(reltoa);
+                    if (reltoi) return this.filter_related_to_incident(reltoi);
+
+                    // Only refresh on initial page load
+                    if (initialLoad) this.refresh();
+                },
                 validateForm() {
                     this.$refs.form.validate().then(({ valid, errors }) => {
                         if (valid) {

--- a/enferno/admin/templates/admin/incidents.html
+++ b/enferno/admin/templates/admin/incidents.html
@@ -716,17 +716,10 @@
 
             methods: {
                 handleRoute({ initialLoad = false } = {}) {
-                    // Use URLSearchParams to reliably read query strings on initial page load 
-                    const params = new URLSearchParams(window.location.search);
-                    const id = this.$route.params.id;
-                    const reltob = params.get('reltob');
-                    const reltoa = params.get('reltoa');
-                    const reltoi = params.get('reltoi');
-
-                    if (id) this.showIncident(id);
-                    if (reltob) return this.filter_related_to_bulletin(reltob);
-                    if (reltoa) return this.filter_related_to_actor(reltoa);
-                    if (reltoi) return this.filter_related_to_incident(reltoi);
+                    if (this.$route.params.id) this.showIncident(this.$route.params.id);
+                    if (this.$route.query.reltob) return this.filter_related_to_bulletin(this.$route.query.reltob);
+                    if (this.$route.query.reltoa) return this.filter_related_to_actor(this.$route.query.reltoa);
+                    if (this.$route.query.reltoi) return this.filter_related_to_incident(this.$route.query.reltoi);
 
                     // Only refresh on initial page load
                     if (initialLoad) this.refresh();
@@ -1559,7 +1552,10 @@
         app.component('RelationEditorCard', RelationEditorCard);
         app.component('EventsSection', EventsSection);
 
-
-        app.use(router).use(vuetify).mount("#app");
+        app.use(router).use(vuetify);
+        router.isReady().then(() => {
+            app.mount('#app');
+            window.app = app;
+        });
     </script>
 {% endblock %}


### PR DESCRIPTION
## Jira Issue
1. [BYNT-1462](https://syriajustice.atlassian.net/browse/BYNT-1462)

## Description
In the preview card of an item, users can see related bulletins, actors, and incidents. Next to each section, there is a button to open the related items in the same tab or a new tab.

Clicking this button loads the related items page, but the results do not appear automatically. Users must manually change the “number of items per page” setting to see the correctly filtered results.

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] New strings prepared for translations

## API Changes (if applicable)
- [ ] Permissions checked
- [ ] Endpoint tests added

## Additional Notes
[Any other relevant information]


[BYNT-1462]: https://syriajustice.atlassian.net/browse/BYNT-1462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ