### PR TITLE
Session Dialog Fix -  Implementation

### DIFF
--- a/enferno/admin/views.py
+++ b/enferno/admin/views.py
@@ -6587,3 +6587,17 @@ def api_bulletin_web_import(validated_data: dict) -> Response:
     )
 
     return HTTPResponse.success(data={"batch_id": data_import.batch_id}, status=202)
+
+
+@admin.route("/api/session-check")
+@auth_required("session")
+def api_session_check() -> Response:
+    """
+    Lightweight endpoint to check if current session is still valid.
+    Used by frontend to detect when session is restored after expiration.
+
+    Returns:
+        - 200: Session is valid
+        - 401: Session expired (handled by auth decorator)
+    """
+    return jsonify({"status": "valid"})


### PR DESCRIPTION
## Problem

When a user's session expires and they get a "Session Expired" dialog, if they log back in from another tab, the dialog gets stuck and can't be dismissed.

## Solution

Check if session is restored when user focuses back on the tab with the stuck dialog.

## Backend (Already Done) ✅

New endpoint available:

```
GET /admin/api/session-check
- 200: Session valid
- 401: Session expired
```

## Frontend Implementation

**File to modify:** `/enferno/static/js/mixins/reauth-mixin.js`

### Step 1: Add session check method

```javascript
methods: {
  // ... existing methods
  
  onFocusProbe: async function() {
    // Only check if dialog is visible
    if (!(this.isSignInDialogVisible || this.isReauthDialogVisible)) return;
    
    try {
      await axios.get('/admin/api/session-check', { suppressGlobalErrorHandler: true });
      this.resetState(); // Session restored - close dialog
    } catch (error) {
      // Still expired - keep dialog open
    }
  }
}
```

### Step 2: Start listening when dialog shows

```javascript
showLoginDialog(event) {
  if (this.isReauthRequired(event?.detail)) {
    this.isReauthDialogVisible = true;
  } else {
    this.isSignInDialogVisible = true;
  }
  
  // Start listening for tab focus
  window.addEventListener('focus', this.onFocusProbe);
}
```

### Step 3: Stop listening when dialog closes

```javascript
resetState() {
  // Stop listening when dialog closes
  window.removeEventListener('focus', this.onFocusProbe);
  
  // ... existing reset logic
  this.signInForm = {
    username: window.__username__ || null,
    password: null,
    csrf_token: null
  };
  this.isSignInDialogLoading = false;
  this.isSignInDialogVisible = false;
  this.isReauthDialogVisible = false;
  this.signInErrorMessage = null;
  this.twoFaSelectForm = null;
  this.verificationCode = null;
  this.signInStep = 'sign-in';
}
```

## How It Works

1. Dialog appears when session expires
2. User logs in from another tab  
3. User switches back to original tab (triggers `focus` event)
4. Code checks `/admin/api/session-check`
5. If session valid → dialog closes automatically
6. User continues their work

## Testing

1. **Single tab**: Session expires → log in same tab → works as normal
2. **Multi-tab**: Tab A expires → Tab B log in → Switch to Tab A → dialog closes
3. **Edge case**: Close dialog manually → stops listening correctly

That's it! Simple focus-based solution that preserves user work and requires minimal code changes.