### PR TITLE
Add verified labels field to short actor form

### DIFF
--- a/enferno/static/js/components/ShortActorDialog.js
+++ b/enferno/static/js/components/ShortActorDialog.js
@@ -434,6 +434,20 @@ const ShortActorDialog = Vue.defineComponent({
                                               <!-- Labels -->
                                               <search-field v-model="profile.labels" api="/admin/api/labels/" item-title="title" item-value="id" :multiple="true" :show-copy-icon="advFeatures" :label="translations.labels_"></search-field>
                                           </v-card-text>
+
+                                          <v-card-text>
+                                              <!-- Verified Labels -->
+                                              <search-field
+                                                    v-model="profile.ver_labels"
+                                                    api="/admin/api/labels/"
+                                                    :query-params="{ fltr: 'verified', typ: 'for_actor' }"
+                                                    item-title="title"
+                                                    item-value="id"
+                                                    :multiple="true"
+                                                    :show-copy-icon="advFeatures"
+                                                    :label="translations.verifiedLabels_"
+                                            ></search-field>
+                                          </v-card-text>
                                       </v-card>
                                   </v-window-item>
                               </v-window>


### PR DESCRIPTION
## Jira Issue
1. [BYNT-1469](https://syriajustice.atlassian.net/browse/BYNT-1469)

## Description
#### Issue
The **Verified labels** field was missing in the **Short Actor Dialog** form, preventing users from selecting verified labels when creating a new actor from the short form.

##### Solution
- Added the **Verified labels** field to the **Short Actor Dialog** form.
- Ensured it loads correctly and behaves consistently with the full actor creation form.

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] New strings prepared for translations

## API Changes (if applicable)
- [ ] Permissions checked
- [ ] Endpoint tests added

## Additional Notes
[Any other relevant information]
