### PR TITLE
Add Alembic database migrations

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -71,6 +71,8 @@ export default withMermaid(
             items: [
               { text: "Installation", link: "/deployment/installation" },
               { text: "Configuration", link: "/deployment/configuration" },
+              { text: "Upgrading", link: "/deployment/upgrading" },
+              { text: "Database Migrations", link: "/deployment/migrations" },
               { text: "Docker", link: "/deployment/docker" },
               { text: "Backups", link: "/deployment/backups" },
             ],

--- a/docs/deployment/migrations.md
+++ b/docs/deployment/migrations.md
@@ -1,0 +1,75 @@
+# Database Migrations
+
+Bayanat uses [Alembic](https://alembic.sqlalchemy.org/) via Flask-Migrate to manage database schema changes.
+
+## Creating a Migration
+
+After modifying a SQLAlchemy model, generate a migration:
+
+```bash
+uv run flask db migrate -m "add status index to bulletin"
+```
+
+This auto-detects changes between your models and the database, and generates a revision file in `migrations/versions/`.
+
+**Always review the generated file.** Alembic's autogenerate is good but not perfect. It may miss:
+- Table or column renames (detected as drop + add)
+- Changes to CHECK constraints
+- Custom SQL functions
+- Data migrations
+
+## Manual Migrations
+
+For changes Alembic can't auto-detect, create an empty revision and write the SQL:
+
+```bash
+uv run flask db revision -m "add custom GIN index"
+```
+
+Then edit the generated file:
+
+```python
+def upgrade():
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_my_index "
+        "ON my_table USING gin (my_column)"
+    )
+
+def downgrade():
+    op.execute("DROP INDEX IF EXISTS ix_my_index")
+```
+
+::: warning JSON in raw SQL
+SQLAlchemy's `text()` parser treats `:word` as a bind parameter. If your SQL contains JSON with colons (e.g. `{"key":true}`), use `conn.exec_driver_sql()` instead of `op.execute()`:
+
+```python
+conn = op.get_bind()
+conn.exec_driver_sql("INSERT INTO t (data) VALUES ('{\"key\":true}'::jsonb)")
+```
+:::
+
+## Applying Migrations
+
+```bash
+uv run flask db upgrade      # apply all pending migrations
+uv run flask db upgrade +1   # apply next migration only
+uv run flask db downgrade -1 # roll back last migration
+```
+
+## Conventions
+
+- Keep migrations small and focused. One logical change per revision.
+- Add `IF NOT EXISTS` / `IF EXISTS` guards to DDL for idempotency.
+- Define indexes in both the model (`__table_args__`) and the migration so `flask db check` shows zero drift.
+- Test migrations on a copy of production data before deploying.
+- Use `op.execute()` for raw SQL. Use `conn.exec_driver_sql()` only when SQL contains JSON colons.
+
+## Fresh Installs
+
+For new deployments, `flask create-db` builds the full schema from models. Then run:
+
+```bash
+uv run flask db upgrade
+```
+
+This stamps the baseline as applied without running it (the schema already exists).

--- a/docs/deployment/upgrading.md
+++ b/docs/deployment/upgrading.md
@@ -1,0 +1,53 @@
+# Upgrading
+
+## Standard Upgrade
+
+Pull the latest code and run database migrations:
+
+```bash
+cd /bayanat
+sudo -u bayanat git pull
+sudo -u bayanat uv sync --frozen
+sudo -u bayanat uv run flask db upgrade
+sudo systemctl restart bayanat bayanat-celery
+```
+
+`flask db upgrade` is idempotent. It detects what's already applied and skips it. Safe to run multiple times.
+
+## First-Time Alembic Upgrade
+
+If upgrading from a version before Alembic was introduced, the process is the same:
+
+```bash
+sudo -u bayanat uv run flask db upgrade
+```
+
+The baseline migration consolidates all previous SQL migrations. It checks your database state and applies only what's missing, regardless of which version you're upgrading from.
+
+::: tip
+You no longer need to manually apply SQL files from `enferno/migrations/`. The `flask db upgrade` command handles everything automatically.
+:::
+
+## Checking Status
+
+See which migration your database is on:
+
+```bash
+uv run flask db current
+```
+
+Check if your schema matches the models:
+
+```bash
+uv run flask db check
+```
+
+## Troubleshooting
+
+**Migration fails partway through:**
+
+Alembic runs inside a transaction. If a migration fails, the entire revision is rolled back. Fix the issue and run `flask db upgrade` again.
+
+**Schema drift detected after upgrade:**
+
+Run `flask db check`. If it reports unexpected differences, this may indicate a manual schema change that wasn't captured in a migration. Contact the development team.

--- a/enferno/admin/models/DynamicField.py
+++ b/enferno/admin/models/DynamicField.py
@@ -139,7 +139,13 @@ class DynamicField(db.Model, BaseMixin):
     sort_order = db.Column(db.Integer, default=0)  # Field display order within entity
     core = db.Column(db.Boolean, default=False)  # Whether this is a core (built-in) field
 
-    __table_args__ = (db.UniqueConstraint("name", "entity_type", name="uq_field_name_entity"),)
+    __table_args__ = (
+        db.UniqueConstraint("name", "entity_type", name="uq_field_name_entity"),
+        db.Index("ix_dynamic_fields_entity_type", "entity_type"),
+        db.Index("ix_dynamic_fields_entity_active", "entity_type", "active"),
+        db.Index("ix_dynamic_fields_entity_core", "entity_type", "core"),
+        db.Index("ix_dynamic_fields_entity_sort", "entity_type", "sort_order"),
+    )
 
     def __init__(self, *args, **kwargs):
         self._validated = False

--- a/enferno/admin/models/DynamicFormHistory.py
+++ b/enferno/admin/models/DynamicFormHistory.py
@@ -20,6 +20,11 @@ class DynamicFormHistory(db.Model, BaseMixin):
     """
 
     __tablename__ = "dynamic_form_history"
+    __table_args__ = (
+        db.Index("ix_dynamic_form_history_entity_type", "entity_type"),
+        db.Index("ix_dynamic_form_history_created_at", db.desc("created_at")),
+        db.Index("ix_dynamic_form_history_entity_created", "entity_type", db.desc("created_at")),
+    )
 
     id = db.Column(db.Integer, primary_key=True)
     entity_type = db.Column(db.String(50), nullable=False)  # bulletin, actor, incident

--- a/enferno/admin/models/Extraction.py
+++ b/enferno/admin/models/Extraction.py
@@ -1,5 +1,7 @@
 """Text extraction results from OCR processing."""
 
+from sqlalchemy import Index, text
+
 from enferno.extensions import db
 from enferno.utils.base import BaseMixin
 from enferno.utils.date_helper import DateHelper
@@ -9,9 +11,24 @@ class Extraction(db.Model, BaseMixin):
     """OCR extraction result linked 1:1 with Media."""
 
     __tablename__ = "extraction"
+    __table_args__ = (
+        Index("ix_extraction_status", "status"),
+        Index("ix_extraction_confidence", "confidence"),
+        Index(
+            "ix_extraction_search_text_trgm",
+            "search_text",
+            postgresql_using="gin",
+            postgresql_ops={"search_text": "gin_trgm_ops"},
+        ),
+    )
 
     id = db.Column(db.Integer, primary_key=True)
-    media_id = db.Column(db.Integer, db.ForeignKey("media.id"), unique=True, nullable=False)
+    media_id = db.Column(
+        db.Integer,
+        db.ForeignKey("media.id", name="fk_extraction_media_id", ondelete="CASCADE"),
+        unique=True,
+        nullable=False,
+    )
 
     text = db.Column(db.Text)
     original_text = db.Column(db.Text)

--- a/enferno/admin/models/Media.py
+++ b/enferno/admin/models/Media.py
@@ -63,7 +63,7 @@ class Media(db.Model, BaseMixin):
         ),
     )
 
-    time = db.Column(db.Float(precision=2))
+    time = db.Column(db.Float())
 
     user_id = db.Column(db.Integer, db.ForeignKey("user.id"))
     user = db.relationship("User", backref="user_medias", foreign_keys=[user_id])

--- a/enferno/app.py
+++ b/enferno/app.py
@@ -32,7 +32,17 @@ from enferno.admin.models import (
 )
 from enferno.admin.views import admin
 from enferno.data_import.views import imports
-from enferno.extensions import db, session, babel, rds, debug_toolbar, mail, limiter, talisman
+from enferno.extensions import (
+    db,
+    migrate,
+    session,
+    babel,
+    rds,
+    debug_toolbar,
+    mail,
+    limiter,
+    talisman,
+)
 from enferno.public.views import bp_public
 from enferno.setup.views import bp_setup
 from enferno.settings import Config
@@ -97,6 +107,7 @@ def register_extensions(app):
         app: Flask application instance
     """
     db.init_app(app)
+    migrate.init_app(app, db)
     # Skip debug toolbar when CSP is enabled (they conflict)
     if not app.config.get("CSP_ENABLED", False):
         debug_toolbar.init_app(app)

--- a/enferno/extensions.py
+++ b/enferno/extensions.py
@@ -6,6 +6,7 @@ in app.py
 from flask_limiter.util import get_remote_address
 from flask_limiter import Limiter
 from flask_sqlalchemy import SQLAlchemy
+from flask_migrate import Migrate
 from flask_session import Session
 from flask_redis import FlaskRedis
 from flask_babel import Babel
@@ -17,6 +18,7 @@ from enferno.utils.rate_limit_utils import get_real_ip
 from enferno.settings import Config
 
 db = SQLAlchemy()
+migrate = Migrate()
 session = Session()
 rds = FlaskRedis()
 babel = Babel()

--- a/migrations/README
+++ b/migrations/README
@@ -1,0 +1,1 @@
+Single-database configuration for Flask.

--- a/migrations/alembic.ini
+++ b/migrations/alembic.ini
@@ -1,0 +1,50 @@
+# A generic, single database configuration.
+
+[alembic]
+# template used to generate migration files
+# file_template = %%(rev)s_%%(slug)s
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic,flask_migrate
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[logger_flask_migrate]
+level = INFO
+handlers =
+qualname = flask_migrate
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,128 @@
+import logging
+from logging.config import fileConfig
+
+from flask import current_app
+
+from alembic import context
+from geoalchemy2 import alembic_helpers
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+fileConfig(config.config_file_name)
+logger = logging.getLogger("alembic.env")
+
+# Exclude PostGIS internal tables from autogenerate
+EXCLUDE_TABLES = {"spatial_ref_sys"}
+
+
+def include_object(object, name, type_, reflected, compare_to):
+    if type_ == "table" and name in EXCLUDE_TABLES:
+        return False
+    return True
+
+
+def get_engine():
+    try:
+        # this works with Flask-SQLAlchemy<3 and Alchemical
+        return current_app.extensions["migrate"].db.get_engine()
+    except (TypeError, AttributeError):
+        # this works with Flask-SQLAlchemy>=3
+        return current_app.extensions["migrate"].db.engine
+
+
+def get_engine_url():
+    try:
+        return get_engine().url.render_as_string(hide_password=False).replace("%", "%%")
+    except AttributeError:
+        return str(get_engine().url).replace("%", "%%")
+
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+config.set_main_option("sqlalchemy.url", get_engine_url())
+target_db = current_app.extensions["migrate"].db
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def get_metadata():
+    if hasattr(target_db, "metadatas"):
+        return target_db.metadatas[None]
+    return target_db.metadata
+
+
+def run_migrations_offline():
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=get_metadata(),
+        literal_binds=True,
+        include_object=include_object,
+        render_item=alembic_helpers.render_item,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+
+    # this callback is used to prevent an auto-migration from being generated
+    # when there are no changes to the schema
+    # reference: http://alembic.zzzcomputing.com/en/latest/cookbook.html
+    def process_revision_directives(context, revision, directives):
+        if getattr(config.cmd_opts, "autogenerate", False):
+            script = directives[0]
+            if script.upgrade_ops.is_empty():
+                directives[:] = []
+                logger.info("No changes in schema detected.")
+
+    conf_args = current_app.extensions["migrate"].configure_args
+    if conf_args.get("process_revision_directives") is None:
+        conf_args["process_revision_directives"] = process_revision_directives
+
+    connectable = get_engine()
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=get_metadata(),
+            include_object=include_object,
+            render_item=alembic_helpers.render_item,
+            **conf_args,
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/migrations/versions/6bbb9e68dc26_baseline_schema_v3_0_0.py
+++ b/migrations/versions/6bbb9e68dc26_baseline_schema_v3_0_0.py
@@ -1,0 +1,28 @@
+"""baseline schema v3.0.0
+
+This is the baseline migration for Bayanat v3.0.0.
+
+For existing deployments: run `flask db stamp head` to mark this as applied.
+For new deployments: `flask create-db` builds the full schema, then `flask db stamp head`.
+
+Revision ID: 6bbb9e68dc26
+Revises:
+Create Date: 2026-03-26 16:17:37.547634
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "6bbb9e68dc26"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Baseline: schema already exists via create-db or prior manual migrations.
+    pass
+
+
+def downgrade():
+    # Cannot downgrade past the baseline.
+    raise RuntimeError("Cannot downgrade past the baseline migration.")

--- a/migrations/versions/6bbb9e68dc26_baseline_schema_v3_0_0.py
+++ b/migrations/versions/6bbb9e68dc26_baseline_schema_v3_0_0.py
@@ -1,15 +1,21 @@
 """baseline schema v3.0.0
 
-This is the baseline migration for Bayanat v3.0.0.
+Consolidates all legacy SQL migrations into one idempotent Alembic revision.
+Safe to run on any Bayanat version (v2.4+). All statements use IF EXISTS /
+IF NOT EXISTS / ON CONFLICT / exception guards so they skip work already done.
 
-For existing deployments: run `flask db stamp head` to mark this as applied.
-For new deployments: `flask create-db` builds the full schema, then `flask db stamp head`.
+For fresh installs: create-db builds the full schema, then `flask db upgrade`
+runs this (mostly no-ops) and stamps it.
+
+For existing deployments: `flask db upgrade` applies anything missing.
 
 Revision ID: 6bbb9e68dc26
 Revises:
 Create Date: 2026-03-26 16:17:37.547634
 
 """
+
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "6bbb9e68dc26"
@@ -19,10 +25,661 @@ depends_on = None
 
 
 def upgrade():
-    # Baseline: schema already exists via create-db or prior manual migrations.
-    pass
+    conn = op.get_bind()
+
+    # Helper: check if a column exists
+    def col_exists(table, column):
+        result = conn.execute(
+            sa.text(
+                "SELECT 1 FROM information_schema.columns "
+                "WHERE table_name = :t AND column_name = :c"
+            ),
+            {"t": table, "c": column},
+        )
+        return result.scalar() is not None
+
+    # Helper: check if a table exists
+    def table_exists(table):
+        result = conn.execute(
+            sa.text(
+                "SELECT 1 FROM information_schema.tables "
+                "WHERE table_name = :t AND table_schema = 'public'"
+            ),
+            {"t": table},
+        )
+        return result.scalar() is not None
+
+    # Helper: check if a constraint exists
+    def constraint_exists(table, constraint):
+        result = conn.execute(
+            sa.text(
+                "SELECT 1 FROM information_schema.table_constraints "
+                "WHERE table_name = :t AND constraint_name = :c"
+            ),
+            {"t": table, "c": constraint},
+        )
+        return result.scalar() is not None
+
+    # ==========================================
+    # 1. Origin ID indices (replace btree with GIN trigram)
+    # ==========================================
+    op.execute("DROP INDEX IF EXISTS ix_actor_profile_originid")
+    op.execute("DROP INDEX IF EXISTS ix_bulletin_originid")
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_bulletin_originid_gin "
+        "ON bulletin USING gin (originid gin_trgm_ops)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_actor_profile_originid_gin "
+        "ON actor_profile USING gin (originid gin_trgm_ops)"
+    )
+
+    # ==========================================
+    # 2. Export: rename ref -> tags (v2.4 -> v2.9)
+    # ==========================================
+    if col_exists("export", "ref") and not col_exists("export", "tags"):
+        op.execute("ALTER TABLE export RENAME COLUMN ref TO tags")
+    if col_exists("export", "tags"):
+        op.execute("UPDATE export SET tags = '{}' WHERE tags IS NULL")
+        op.execute("ALTER TABLE export ALTER COLUMN tags SET NOT NULL")
+        op.execute("ALTER TABLE export ALTER COLUMN tags SET DEFAULT '{}'")
+
+    # ==========================================
+    # 3. Search optimization indexes (all IF NOT EXISTS)
+    # ==========================================
+    _create_search_indexes(op)
+
+    # ==========================================
+    # 4. ID number types table + actor id_number migration
+    # ==========================================
+    if not table_exists("id_number_types"):
+        op.execute(
+            """
+            CREATE TABLE id_number_types (
+                id SERIAL PRIMARY KEY,
+                title VARCHAR NOT NULL,
+                title_tr VARCHAR,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                deleted BOOLEAN DEFAULT FALSE
+            )
+        """
+        )
+        op.execute(
+            """
+            INSERT INTO id_number_types (title, title_tr) VALUES
+                ('National ID', ''), ('Passport', ''), ('Driver License', ''),
+                ('Social Security Number', ''), ('Tax ID', ''), ('Military ID', ''),
+                ('Birth Certificate', ''), ('Student ID', '')
+        """
+        )
+    else:
+        # Ensure National ID with id=1 exists for the migration below
+        op.execute(
+            "INSERT INTO id_number_types (id, title, title_tr, created_at, updated_at, deleted) "
+            "VALUES (1, 'National ID', '', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, FALSE) "
+            "ON CONFLICT (id) DO NOTHING"
+        )
+
+    # Actor id_number: string -> JSONB array (only if still a string column)
+    if col_exists("actor", "id_number"):
+        # Check if it's already JSONB
+        result = conn.execute(
+            sa.text(
+                "SELECT data_type FROM information_schema.columns "
+                "WHERE table_name = 'actor' AND column_name = 'id_number'"
+            )
+        )
+        row = result.fetchone()
+        if row and row[0] not in ("jsonb",):
+            _migrate_actor_id_number(op)
+
+    # ==========================================
+    # 5. Notification table
+    # ==========================================
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS notification (
+            id SERIAL PRIMARY KEY,
+            user_id INTEGER NOT NULL,
+            title VARCHAR NOT NULL,
+            message TEXT NOT NULL,
+            category VARCHAR NOT NULL DEFAULT 'Update',
+            read_status BOOLEAN DEFAULT FALSE,
+            read_at TIMESTAMP,
+            is_urgent BOOLEAN DEFAULT FALSE,
+            email_enabled BOOLEAN DEFAULT FALSE,
+            email_sent BOOLEAN DEFAULT FALSE,
+            email_sent_at TIMESTAMP,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            deleted BOOLEAN DEFAULT FALSE
+        )
+    """
+    )
+    op.execute("CREATE INDEX IF NOT EXISTS ix_notification_user_id ON notification (user_id)")
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_notification_user_read "
+        "ON notification (user_id, read_status)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_notification_user_type "
+        "ON notification (user_id, category)"
+    )
+    op.execute(
+        """
+        DO $$ BEGIN
+            ALTER TABLE notification ADD CONSTRAINT fk_notification_user_id
+            FOREIGN KEY (user_id) REFERENCES "user"(id);
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END $$
+    """
+    )
+
+    # ==========================================
+    # 6. Dynamic fields + form history tables
+    # ==========================================
+    _create_dynamic_fields_tables(op)
+    _seed_core_fields(conn)
+
+    # ==========================================
+    # 7. Actor meta GIN index
+    # ==========================================
+    op.execute("CREATE INDEX IF NOT EXISTS ix_actor_meta_gin ON actor USING gin (meta)")
+
+    # ==========================================
+    # 8. Extraction table (OCR)
+    # ==========================================
+    _create_extraction_table(op)
+
+    # ==========================================
+    # 9. Label constraints
+    # ==========================================
+    if not constraint_exists("label", "label_no_self_parent"):
+        op.execute(
+            "ALTER TABLE label ADD CONSTRAINT label_no_self_parent CHECK (parent_label_id != id)"
+        )
+    if not constraint_exists("label", "label_unique_sibling_title"):
+        op.execute(
+            "ALTER TABLE label ADD CONSTRAINT label_unique_sibling_title "
+            "UNIQUE (title, parent_label_id)"
+        )
+
+    # ==========================================
+    # 10. OCR simplification (history column, orientation on media)
+    # ==========================================
+    op.execute(
+        "ALTER TABLE extraction ADD COLUMN IF NOT EXISTS "
+        "history JSONB DEFAULT '[]'::jsonb NOT NULL"
+    )
+    op.execute("ALTER TABLE media ADD COLUMN IF NOT EXISTS orientation INTEGER DEFAULT 0")
+    # Migrate orientation data (idempotent: overwrites with same value)
+    op.execute(
+        "UPDATE media SET orientation = e.orientation "
+        "FROM extraction e WHERE e.media_id = media.id AND e.orientation != 0"
+    )
+    # Normalize statuses
+    op.execute(
+        "UPDATE extraction SET status = 'processed' "
+        "WHERE status IN ('needs_review', 'needs_transcription')"
+    )
+
+    # ==========================================
+    # 11. Normalize search_text newlines
+    # ==========================================
+    # Recreate generated column (DROP + ADD is idempotent for generated columns)
+    if table_exists("extraction"):
+        op.execute("ALTER TABLE extraction DROP COLUMN IF EXISTS search_text")
+        op.execute(
+            "ALTER TABLE extraction ADD COLUMN search_text text "
+            "GENERATED ALWAYS AS (normalize_arabic_text(text)) STORED"
+        )
+        op.execute(
+            "CREATE INDEX IF NOT EXISTS ix_extraction_search_text_trgm "
+            "ON extraction USING GIN(search_text gin_trgm_ops)"
+        )
+
+    # ==========================================
+    # 12. User can_access_media column
+    # ==========================================
+    op.execute('ALTER TABLE "user" ADD COLUMN IF NOT EXISTS can_access_media BOOLEAN DEFAULT FALSE')
+
+    # ==========================================
+    # 13. Fix deleted column NOT NULL on all tables
+    # ==========================================
+    _fix_deleted_columns(op)
 
 
 def downgrade():
-    # Cannot downgrade past the baseline.
     raise RuntimeError("Cannot downgrade past the baseline migration.")
+
+
+# --- Helper functions ---
+
+import sqlalchemy as sa
+
+
+def _create_search_indexes(op):
+    """Create all search optimization indexes (all IF NOT EXISTS)."""
+    indexes = [
+        # Bulletin
+        "CREATE INDEX IF NOT EXISTS ix_bulletin_assigned_to_id ON bulletin(assigned_to_id)",
+        "CREATE INDEX IF NOT EXISTS ix_bulletin_first_peer_reviewer_id ON bulletin(first_peer_reviewer_id)",
+        "CREATE INDEX IF NOT EXISTS ix_bulletin_second_peer_reviewer_id ON bulletin(second_peer_reviewer_id)",
+        "CREATE INDEX IF NOT EXISTS ix_event_location_id ON event(location_id)",
+        "CREATE INDEX IF NOT EXISTS ix_event_eventtype_id ON event(eventtype_id)",
+        "CREATE INDEX IF NOT EXISTS ix_bulletin_sources_source_id ON bulletin_sources(source_id)",
+        "CREATE INDEX IF NOT EXISTS ix_bulletin_sources_bulletin_id ON bulletin_sources(bulletin_id)",
+        "CREATE INDEX IF NOT EXISTS ix_bulletin_labels_label_id ON bulletin_labels(label_id)",
+        "CREATE INDEX IF NOT EXISTS ix_bulletin_labels_bulletin_id ON bulletin_labels(bulletin_id)",
+        "CREATE INDEX IF NOT EXISTS ix_bulletin_verlabels_label_id ON bulletin_verlabels(label_id)",
+        "CREATE INDEX IF NOT EXISTS ix_bulletin_verlabels_bulletin_id ON bulletin_verlabels(bulletin_id)",
+        "CREATE INDEX IF NOT EXISTS ix_bulletin_locations_location_id ON bulletin_locations(location_id)",
+        "CREATE INDEX IF NOT EXISTS ix_bulletin_locations_bulletin_id ON bulletin_locations(bulletin_id)",
+        "CREATE INDEX IF NOT EXISTS ix_bulletin_roles_role_id ON bulletin_roles(role_id)",
+        "CREATE INDEX IF NOT EXISTS ix_bulletin_roles_bulletin_id ON bulletin_roles(bulletin_id)",
+        "CREATE INDEX IF NOT EXISTS ix_bulletin_events_event_id ON bulletin_events(event_id)",
+        "CREATE INDEX IF NOT EXISTS ix_bulletin_events_bulletin_id ON bulletin_events(bulletin_id)",
+        "CREATE INDEX IF NOT EXISTS ix_bulletin_status ON bulletin(status)",
+        "CREATE INDEX IF NOT EXISTS ix_bulletin_tags_gin ON bulletin USING gin(tags)",
+        "CREATE INDEX IF NOT EXISTS ix_bulletin_status_assigned ON bulletin(status, assigned_to_id)",
+        # Actor
+        "CREATE INDEX IF NOT EXISTS ix_actor_assigned_to_id ON actor(assigned_to_id)",
+        "CREATE INDEX IF NOT EXISTS ix_actor_first_peer_reviewer_id ON actor(first_peer_reviewer_id)",
+        "CREATE INDEX IF NOT EXISTS ix_actor_second_peer_reviewer_id ON actor(second_peer_reviewer_id)",
+        "CREATE INDEX IF NOT EXISTS ix_actor_origin_place_id ON actor(origin_place_id)",
+        "CREATE INDEX IF NOT EXISTS ix_actor_sources_source_id ON actor_sources(source_id)",
+        "CREATE INDEX IF NOT EXISTS ix_actor_sources_actor_profile_id ON actor_sources(actor_profile_id)",
+        "CREATE INDEX IF NOT EXISTS ix_actor_labels_label_id ON actor_labels(label_id)",
+        "CREATE INDEX IF NOT EXISTS ix_actor_labels_actor_profile_id ON actor_labels(actor_profile_id)",
+        "CREATE INDEX IF NOT EXISTS ix_actor_verlabels_label_id ON actor_verlabels(label_id)",
+        "CREATE INDEX IF NOT EXISTS ix_actor_verlabels_actor_profile_id ON actor_verlabels(actor_profile_id)",
+        "CREATE INDEX IF NOT EXISTS ix_actor_events_event_id ON actor_events(event_id)",
+        "CREATE INDEX IF NOT EXISTS ix_actor_events_actor_id ON actor_events(actor_id)",
+        "CREATE INDEX IF NOT EXISTS ix_actor_roles_role_id ON actor_roles(role_id)",
+        "CREATE INDEX IF NOT EXISTS ix_actor_roles_actor_id ON actor_roles(actor_id)",
+        "CREATE INDEX IF NOT EXISTS ix_actor_tags ON actor USING gin (tags array_ops)",
+        # Incident
+        "CREATE INDEX IF NOT EXISTS ix_incident_assigned_to_id ON incident(assigned_to_id)",
+        "CREATE INDEX IF NOT EXISTS ix_incident_first_peer_reviewer_id ON incident(first_peer_reviewer_id)",
+        "CREATE INDEX IF NOT EXISTS ix_incident_second_peer_reviewer_id ON incident(second_peer_reviewer_id)",
+        "CREATE INDEX IF NOT EXISTS ix_incident_labels_label_id ON incident_labels(label_id)",
+        "CREATE INDEX IF NOT EXISTS ix_incident_labels_incident_id ON incident_labels(incident_id)",
+        "CREATE INDEX IF NOT EXISTS ix_incident_locations_location_id ON incident_locations(location_id)",
+        "CREATE INDEX IF NOT EXISTS ix_incident_locations_incident_id ON incident_locations(incident_id)",
+        "CREATE INDEX IF NOT EXISTS ix_incident_events_event_id ON incident_events(event_id)",
+        "CREATE INDEX IF NOT EXISTS ix_incident_events_incident_id ON incident_events(incident_id)",
+        "CREATE INDEX IF NOT EXISTS ix_incident_roles_role_id ON incident_roles(role_id)",
+        "CREATE INDEX IF NOT EXISTS ix_incident_roles_incident_id ON incident_roles(incident_id)",
+        "CREATE INDEX IF NOT EXISTS ix_incident_potential_violations_potentialviolation_id ON incident_potential_violations(potentialviolation_id)",
+        "CREATE INDEX IF NOT EXISTS ix_incident_potential_violations_incident_id ON incident_potential_violations(incident_id)",
+        "CREATE INDEX IF NOT EXISTS ix_incident_claimed_violations_claimedviolation_id ON incident_claimed_violations(claimedviolation_id)",
+        "CREATE INDEX IF NOT EXISTS ix_incident_claimed_violations_incident_id ON incident_claimed_violations(incident_id)",
+    ]
+    for stmt in indexes:
+        op.execute(stmt)
+
+
+def _migrate_actor_id_number(op):
+    """Convert actor.id_number from string to JSONB array."""
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION validate_actor_id_number(id_number_data JSONB)
+        RETURNS BOOLEAN AS $$
+        BEGIN
+            IF jsonb_typeof(id_number_data) != 'array' THEN RETURN FALSE; END IF;
+            IF jsonb_array_length(id_number_data) = 0 THEN RETURN TRUE; END IF;
+            RETURN (
+                SELECT bool_and(
+                    jsonb_typeof(elem->'type') = 'string' AND
+                    jsonb_typeof(elem->'number') = 'string' AND
+                    (elem->'type') IS NOT NULL AND
+                    (elem->'number') IS NOT NULL AND
+                    trim((elem->>'type')) != '' AND
+                    trim((elem->>'number')) != '' AND
+                    (elem->>'type') ~ '^[0-9]+$'
+                )
+                FROM jsonb_array_elements(id_number_data) AS elem
+            );
+        END;
+        $$ LANGUAGE plpgsql IMMUTABLE
+    """
+    )
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS actor_id_number_backup AS
+        SELECT id, id_number FROM actor
+        WHERE id_number IS NOT NULL AND id_number != ''
+    """
+    )
+    op.execute("ALTER TABLE actor ADD COLUMN id_number_temp JSONB")
+    op.execute(
+        """
+        UPDATE actor SET id_number_temp = CASE
+            WHEN id_number IS NOT NULL AND trim(id_number) != ''
+            THEN jsonb_build_array(jsonb_build_object('type', '1', 'number', trim(id_number)))
+            ELSE '[]'::jsonb
+        END
+    """
+    )
+    op.execute("ALTER TABLE actor DROP COLUMN id_number")
+    op.execute("ALTER TABLE actor RENAME COLUMN id_number_temp TO id_number")
+    op.execute("ALTER TABLE actor ALTER COLUMN id_number SET DEFAULT '[]'::jsonb")
+    op.execute("ALTER TABLE actor ALTER COLUMN id_number SET NOT NULL")
+    op.execute(
+        "ALTER TABLE actor ADD CONSTRAINT check_actor_id_number_element_structure "
+        "CHECK (validate_actor_id_number(id_number))"
+    )
+    op.execute("CREATE INDEX IF NOT EXISTS ix_actor_id_number_gin ON actor USING GIN (id_number)")
+
+
+def _create_dynamic_fields_tables(op):
+    """Create dynamic_fields and dynamic_form_history tables."""
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS dynamic_fields (
+            id SERIAL PRIMARY KEY,
+            name VARCHAR(50) NOT NULL,
+            title VARCHAR(100) NOT NULL,
+            entity_type VARCHAR(50) NOT NULL,
+            field_type VARCHAR(20) NOT NULL,
+            searchable BOOLEAN NOT NULL DEFAULT FALSE,
+            ui_component VARCHAR(20),
+            schema_config JSONB NOT NULL DEFAULT '{}'::jsonb,
+            ui_config JSONB NOT NULL DEFAULT '{}'::jsonb,
+            validation_config JSONB NOT NULL DEFAULT '{}'::jsonb,
+            options JSONB NOT NULL DEFAULT '[]'::jsonb,
+            active BOOLEAN NOT NULL DEFAULT TRUE,
+            sort_order INTEGER NOT NULL DEFAULT 0,
+            core BOOLEAN NOT NULL DEFAULT FALSE,
+            created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            deleted BOOLEAN NOT NULL DEFAULT FALSE,
+            CONSTRAINT uq_field_name_entity UNIQUE (name, entity_type)
+        )
+    """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_dynamic_fields_entity_type "
+        "ON dynamic_fields (entity_type)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_dynamic_fields_entity_active "
+        "ON dynamic_fields (entity_type, active)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_dynamic_fields_entity_core "
+        "ON dynamic_fields (entity_type, core)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_dynamic_fields_entity_sort "
+        "ON dynamic_fields (entity_type, sort_order)"
+    )
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS dynamic_form_history (
+            id SERIAL PRIMARY KEY,
+            entity_type VARCHAR(50) NOT NULL,
+            fields_snapshot JSONB NOT NULL,
+            user_id INTEGER REFERENCES "user"(id),
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            deleted BOOLEAN DEFAULT FALSE
+        )
+    """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_dynamic_form_history_entity_type "
+        "ON dynamic_form_history (entity_type)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_dynamic_form_history_created_at "
+        "ON dynamic_form_history (created_at DESC)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_dynamic_form_history_entity_created "
+        "ON dynamic_form_history (entity_type, created_at DESC)"
+    )
+
+
+def _seed_core_fields(conn):
+    """Seed core dynamic fields for all entity types."""
+    # Use exec_driver_sql to bypass SQLAlchemy's text() colon parsing,
+    # which conflicts with JSON values like {"key":true}.
+    conn.exec_driver_sql(
+        """
+        INSERT INTO dynamic_fields (
+            name, title, entity_type, field_type, searchable,
+            ui_component, schema_config, ui_config, validation_config,
+            options, active, sort_order, core
+        ) VALUES
+            -- Actor fields
+            ('name', 'Name', 'actor', 'text', false, 'input', '{}'::jsonb, '{"width":"w-100"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 1, true),
+            ('first_name', 'First Name', 'actor', 'text', false, 'input', '{}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 2, true),
+            ('middle_name', 'Middle Name', 'actor', 'text', false, 'input', '{}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 3, true),
+            ('last_name', 'Last Name', 'actor', 'text', false, 'input', '{}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 4, true),
+            ('nickname', 'Nickname', 'actor', 'text', false, 'input', '{}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 5, true),
+            ('father_name', 'Father Name', 'actor', 'text', false, 'input', '{}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 6, true),
+            ('mother_name', 'Mother Name', 'actor', 'text', false, 'input', '{}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 7, true),
+            ('sex', 'Sex', 'actor', 'select', false, 'dropdown', '{"allow_multiple":false}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 8, true),
+            ('age', 'Age', 'actor', 'number', false, 'number_input', '{}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 9, true),
+            ('civilian', 'Civilian', 'actor', 'select', false, 'dropdown', '{"allow_multiple":false}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 10, true),
+            ('origin_place', 'Origin Place', 'actor', 'select', false, 'dropdown', '{"allow_multiple":true}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 11, true),
+            ('occupation', 'Occupation', 'actor', 'text', false, 'input', '{}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 12, true),
+            ('position', 'Position', 'actor', 'text', false, 'input', '{}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 13, true),
+            ('family_status', 'Family Status', 'actor', 'select', false, 'dropdown', '{"allow_multiple":false}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 14, true),
+            ('no_children', 'Number of Children', 'actor', 'number', false, 'number_input', '{}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 15, true),
+            ('ethnographies', 'Ethnographies', 'actor', 'select', false, 'dropdown', '{"allow_multiple":true}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 16, true),
+            ('nationalities', 'Nationalities', 'actor', 'select', false, 'dropdown', '{"allow_multiple":true}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 17, true),
+            ('dialects', 'Dialects', 'actor', 'select', false, 'dropdown', '{"allow_multiple":true}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 18, true),
+            ('tags', 'Tags', 'actor', 'select', false, 'dropdown', '{"allow_multiple":true}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 19, true),
+            ('id_number', 'ID Number', 'actor', 'text', false, 'input', '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 20, true),
+            ('actor_profiles', 'Actor Profiles', 'actor', 'html_block', false, 'html_block', '{}'::jsonb, '{"html_template":"actor_profiles"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 21, true),
+            ('events_section', 'Events', 'actor', 'html_block', false, 'html_block', '{}'::jsonb, '{"html_template":"events_section"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 22, true),
+            ('related_bulletins', 'Related Bulletins', 'actor', 'html_block', false, 'html_block', '{}'::jsonb, '{"html_template":"related_bulletins"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 23, true),
+            ('related_actors', 'Related Actors', 'actor', 'html_block', false, 'html_block', '{}'::jsonb, '{"html_template":"related_actors"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 24, true),
+            ('related_incidents', 'Related Incidents', 'actor', 'html_block', false, 'html_block', '{}'::jsonb, '{"html_template":"related_incidents"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 25, true),
+            ('medias', 'Media', 'actor', 'html_block', false, 'html_block', '{}'::jsonb, '{"html_template":"medias"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 26, true),
+            ('comments', 'Comments', 'actor', 'long_text', false, 'textarea', '{}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 27, true),
+            ('status', 'Status', 'actor', 'select', false, 'dropdown', '{"allow_multiple":false}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 28, true),
+            ('sources', 'Sources', 'actor', 'select', false, 'dropdown', '{"allow_multiple":true}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 29, true),
+            ('labels', 'Labels', 'actor', 'select', false, 'dropdown', '{"allow_multiple":true}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 30, true),
+            ('ver_labels', 'Verified Labels', 'actor', 'select', false, 'dropdown', '{"allow_multiple":true}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 31, true),
+            -- Bulletin fields
+            ('title', 'Original Title', 'bulletin', 'text', false, 'input', '{}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 1, true),
+            ('sjac_title', 'Title', 'bulletin', 'text', false, 'input', '{}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 2, true),
+            ('tags', 'Tags', 'bulletin', 'select', false, 'dropdown', '{"allow_multiple":true}'::jsonb, '{}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 3, true),
+            ('sources', 'Sources', 'bulletin', 'select', false, 'dropdown', '{"allow_multiple":true}'::jsonb, '{}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 4, true),
+            ('description', 'Description', 'bulletin', 'long_text', false, 'textarea', '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 5, true),
+            ('labels', 'Labels', 'bulletin', 'select', false, 'dropdown', '{"allow_multiple":true}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 6, true),
+            ('ver_labels', 'Verified Labels', 'bulletin', 'select', false, 'dropdown', '{"allow_multiple":true}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 7, true),
+            ('locations', 'Locations', 'bulletin', 'select', false, 'dropdown', '{"allow_multiple":true}'::jsonb, '{}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 8, true),
+            ('global_map', 'Global Map', 'bulletin', 'html_block', false, 'html_block', '{}'::jsonb, '{"html_template":"global_map"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 9, true),
+            ('events_section', 'Events', 'bulletin', 'html_block', false, 'html_block', '{}'::jsonb, '{"html_template":"events_section"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 10, true),
+            ('geo_locations', 'Geo Locations', 'bulletin', 'html_block', false, 'html_block', '{}'::jsonb, '{"html_template":"geo_locations"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 11, true),
+            ('related_bulletins', 'Related Bulletins', 'bulletin', 'html_block', false, 'html_block', '{}'::jsonb, '{"html_template":"related_bulletins"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 12, true),
+            ('related_actors', 'Related Actors', 'bulletin', 'html_block', false, 'html_block', '{}'::jsonb, '{"html_template":"related_actors"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 13, true),
+            ('related_incidents', 'Related Incidents', 'bulletin', 'html_block', false, 'html_block', '{}'::jsonb, '{"html_template":"related_incidents"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 14, true),
+            ('source_link', 'Source Link', 'bulletin', 'text', false, 'input', '{}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 15, true),
+            ('publish_date', 'Publish Date', 'bulletin', 'datetime', false, 'date_picker', '{}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 16, true),
+            ('documentation_date', 'Documentation Date', 'bulletin', 'datetime', false, 'date_picker', '{}'::jsonb, '{"align":"right","width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 17, true),
+            ('comments', 'Comments', 'bulletin', 'long_text', false, 'textarea', '{}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 18, true),
+            ('status', 'Status', 'bulletin', 'select', false, 'dropdown', '{"allow_multiple":false}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 19, true),
+            -- Incident fields
+            ('title', 'Title', 'incident', 'text', false, 'input', '{}'::jsonb, '{"width":"w-100"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 1, true),
+            ('description', 'Description', 'incident', 'long_text', false, 'textarea', '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 2, true),
+            ('potential_violations', 'Potential Violations', 'incident', 'select', false, 'dropdown', '{"allow_multiple":true}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 3, true),
+            ('claimed_violations', 'Claimed Violations', 'incident', 'select', false, 'dropdown', '{"allow_multiple":true}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 4, true),
+            ('labels', 'Labels', 'incident', 'select', false, 'dropdown', '{"allow_multiple":true}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 5, true),
+            ('locations', 'Locations', 'incident', 'select', false, 'dropdown', '{"allow_multiple":true}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 6, true),
+            ('events_section', 'Events', 'incident', 'html_block', false, 'html_block', '{}'::jsonb, '{"html_template":"events_section"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 7, true),
+            ('related_bulletins', 'Related Bulletins', 'incident', 'html_block', false, 'html_block', '{}'::jsonb, '{"html_template":"related_bulletins"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 8, true),
+            ('related_actors', 'Related Actors', 'incident', 'html_block', false, 'html_block', '{}'::jsonb, '{"html_template":"related_actors"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 9, true),
+            ('related_incidents', 'Related Incidents', 'incident', 'html_block', false, 'html_block', '{}'::jsonb, '{"html_template":"related_incidents"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 10, true),
+            ('comments', 'Comments', 'incident', 'long_text', false, 'textarea', '{}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 11, true),
+            ('status', 'Status', 'incident', 'select', false, 'dropdown', '{"allow_multiple":false}'::jsonb, '{"width":"w-50"}'::jsonb, '{}'::jsonb, '[]'::jsonb, true, 12, true)
+        ON CONFLICT (name, entity_type) DO NOTHING
+    """
+    )
+
+    # Create initial form history snapshots (only if none exist)
+    op.execute(
+        """
+        INSERT INTO dynamic_form_history (entity_type, fields_snapshot, user_id)
+        SELECT df.entity_type,
+            jsonb_agg(jsonb_build_object(
+                'id', df.id, 'name', df.name, 'title', df.title,
+                'entity_type', df.entity_type, 'field_type', df.field_type,
+                'searchable', df.searchable, 'ui_component', df.ui_component,
+                'schema_config', df.schema_config, 'ui_config', df.ui_config,
+                'validation_config', df.validation_config, 'options', df.options,
+                'active', df.active, 'sort_order', df.sort_order, 'core', df.core
+            ) ORDER BY df.sort_order),
+            NULL
+        FROM dynamic_fields df
+        WHERE df.active = TRUE AND df.deleted = FALSE AND df.core = TRUE
+          AND NOT EXISTS (
+              SELECT 1 FROM dynamic_form_history h WHERE h.entity_type = df.entity_type
+          )
+        GROUP BY df.entity_type
+    """
+    )
+
+
+def _create_extraction_table(op):
+    """Create extraction table with normalize function and indexes."""
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS extraction (
+            id SERIAL PRIMARY KEY,
+            media_id INTEGER NOT NULL UNIQUE,
+            text TEXT,
+            original_text TEXT,
+            raw JSONB,
+            confidence FLOAT,
+            orientation INTEGER DEFAULT 0,
+            status VARCHAR(20) NOT NULL DEFAULT 'pending',
+            manual BOOLEAN NOT NULL DEFAULT FALSE,
+            word_count INTEGER DEFAULT 0,
+            language VARCHAR(10),
+            reviewed_by INTEGER,
+            reviewed_at TIMESTAMP,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            deleted BOOLEAN
+        )
+    """
+    )
+    op.execute("CREATE INDEX IF NOT EXISTS ix_extraction_media_id ON extraction (media_id)")
+    op.execute("CREATE INDEX IF NOT EXISTS ix_extraction_status ON extraction (status)")
+    op.execute("CREATE INDEX IF NOT EXISTS ix_extraction_confidence ON extraction (confidence)")
+
+    # Arabic text normalization function
+    op.execute(
+        r"""
+        CREATE OR REPLACE FUNCTION normalize_arabic_text(input text) RETURNS text AS $$
+        BEGIN
+            IF input IS NULL THEN RETURN NULL; END IF;
+            RETURN translate(
+                input,
+                E'\u0623\u0625\u0622\u0671\u0649\u0629\u0660\u0661\u0662\u0663\u0664\u0665\u0666\u0667\u0668\u0669\u064B\u064C\u064D\u064E\u064F\u0650\u0651\u0652\u0640',
+                E'\u0627\u0627\u0627\u0627\u064A\u06470123456789'
+            );
+        END;
+        $$ LANGUAGE plpgsql IMMUTABLE STRICT
+    """
+    )
+
+    # FK constraints
+    op.execute(
+        """
+        DO $$ BEGIN
+            ALTER TABLE extraction ADD CONSTRAINT fk_extraction_media_id
+            FOREIGN KEY (media_id) REFERENCES media(id) ON DELETE CASCADE;
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END $$
+    """
+    )
+    op.execute(
+        """
+        DO $$ BEGIN
+            ALTER TABLE extraction ADD CONSTRAINT fk_extraction_reviewed_by
+            FOREIGN KEY (reviewed_by) REFERENCES "user"(id);
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END $$
+    """
+    )
+
+
+def _fix_deleted_columns(op):
+    """Set deleted=FALSE where NULL, add NOT NULL + DEFAULT on all tables."""
+    tables = [
+        "activity",
+        "actor",
+        "actor_history",
+        "actor_profile",
+        "app_config",
+        "atoa",
+        "atoa_info",
+        "atob",
+        "atob_info",
+        "btob",
+        "btob_info",
+        "bulletin",
+        "bulletin_history",
+        "claimed_violation",
+        "countries",
+        "dialects",
+        "dynamic_fields",
+        "dynamic_form_history",
+        "ethnographies",
+        "event",
+        "eventtype",
+        "extraction",
+        "geo_location",
+        "geo_location_types",
+        "id_number_types",
+        "incident",
+        "incident_history",
+        "itoa",
+        "itoa_info",
+        "itob",
+        "itob_info",
+        "itoi",
+        "itoi_info",
+        "label",
+        "location",
+        "location_admin_level",
+        "location_history",
+        "location_type",
+        "media",
+        "media_categories",
+        "notification",
+        "potential_violation",
+        "query",
+        "role",
+        "sessions",
+        "settings",
+        "source",
+        "user",
+        "workflow_statuses",
+    ]
+    op.execute(
+        """
+        DO $$
+        DECLARE tbl TEXT;
+            tables TEXT[] := ARRAY[{table_list}];
+        BEGIN
+            FOREACH tbl IN ARRAY tables LOOP
+                EXECUTE format('UPDATE %I SET deleted = FALSE WHERE deleted IS NULL', tbl);
+                EXECUTE format('ALTER TABLE %I ALTER COLUMN deleted SET DEFAULT FALSE', tbl);
+                BEGIN
+                    EXECUTE format('ALTER TABLE %I ALTER COLUMN deleted SET NOT NULL', tbl);
+                EXCEPTION WHEN others THEN NULL;
+                END;
+            END LOOP;
+        END $$
+    """.format(
+            table_list=",".join(f"'{t}'" for t in tables)
+        )
+    )

--- a/migrations/versions/6bbb9e68dc26_baseline_schema_v3_0_0.py
+++ b/migrations/versions/6bbb9e68dc26_baseline_schema_v3_0_0.py
@@ -570,20 +570,23 @@ def _create_extraction_table(op):
         )
     """
     )
-    op.execute("CREATE INDEX IF NOT EXISTS ix_extraction_media_id ON extraction (media_id)")
+    # ix_extraction_media_id omitted: media_id has UNIQUE constraint which creates an index
     op.execute("CREATE INDEX IF NOT EXISTS ix_extraction_status ON extraction (status)")
     op.execute("CREATE INDEX IF NOT EXISTS ix_extraction_confidence ON extraction (confidence)")
 
-    # Arabic text normalization function
+    # Arabic text normalization function (with newline collapsing)
     op.execute(
         r"""
         CREATE OR REPLACE FUNCTION normalize_arabic_text(input text) RETURNS text AS $$
         BEGIN
             IF input IS NULL THEN RETURN NULL; END IF;
-            RETURN translate(
-                input,
-                E'\u0623\u0625\u0622\u0671\u0649\u0629\u0660\u0661\u0662\u0663\u0664\u0665\u0666\u0667\u0668\u0669\u064B\u064C\u064D\u064E\u064F\u0650\u0651\u0652\u0640',
-                E'\u0627\u0627\u0627\u0627\u064A\u06470123456789'
+            RETURN regexp_replace(
+                translate(
+                    input,
+                    E'\u0623\u0625\u0622\u0671\u0649\u0629\u0660\u0661\u0662\u0663\u0664\u0665\u0666\u0667\u0668\u0669\u064B\u064C\u064D\u064E\u064F\u0650\u0651\u0652\u0640',
+                    E'\u0627\u0627\u0627\u0627\u064A\u06470123456789'
+                ),
+                E'[\r\n]+', ' ', 'g'
             );
         END;
         $$ LANGUAGE plpgsql IMMUTABLE STRICT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
     "Flask-Babel>=4.0.0",
     "Flask-Limiter>=3.0",
     "Flask-Login>=0.6.3",
+    "Flask-Migrate>=4.1.0",
     "Flask-Mail>=0.10.0",
     "Flask-Principal>=0.4.0",
     "flask-redis>=0.4.0",

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,20 @@ resolution-markers = [
 constraints = [{ name = "pip", specifier = ">=26.0" }]
 
 [[package]]
+name = "alembic"
+version = "1.18.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mako" },
+    { name = "sqlalchemy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725, upload-time = "2026-02-10T16:00:47.195Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl", hash = "sha256:a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a", size = 263893, upload-time = "2026-02-10T16:00:49.997Z" },
+]
+
+[[package]]
 name = "amqp"
 version = "5.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -185,6 +199,7 @@ dependencies = [
     { name = "flask-limiter" },
     { name = "flask-login" },
     { name = "flask-mail" },
+    { name = "flask-migrate" },
     { name = "flask-principal" },
     { name = "flask-redis" },
     { name = "flask-script" },
@@ -316,6 +331,7 @@ requires-dist = [
     { name = "flask-limiter", specifier = ">=3.0" },
     { name = "flask-login", specifier = ">=0.6.3" },
     { name = "flask-mail", specifier = ">=0.10.0" },
+    { name = "flask-migrate", specifier = ">=4.1.0" },
     { name = "flask-principal", specifier = ">=0.4.0" },
     { name = "flask-pydantic", marker = "extra == 'dev'", specifier = ">=0.13.0" },
     { name = "flask-redis", specifier = ">=0.4.0" },
@@ -1266,6 +1282,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ba/29/e92dc84c675d1e8d260d5768eb3fb65c70cbd33addecf424187587bee862/flask_mail-0.10.0.tar.gz", hash = "sha256:44083e7b02bbcce792209c06252f8569dd5a325a7aaa76afe7330422bd97881d", size = 8152, upload-time = "2024-05-23T22:30:12.612Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/c0/a81083da779f482494d49195d8b6c9fde21072558253e4a9fb2ec969c3c1/flask_mail-0.10.0-py3-none-any.whl", hash = "sha256:a451e490931bb3441d9b11ebab6812a16bfa81855792ae1bf9c1e1e22c4e51e7", size = 8529, upload-time = "2024-05-23T22:30:10.962Z" },
+]
+
+[[package]]
+name = "flask-migrate"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "alembic" },
+    { name = "flask" },
+    { name = "flask-sqlalchemy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/8e/47c7b3c93855ceffc2eabfa271782332942443321a07de193e4198f920cf/flask_migrate-4.1.0.tar.gz", hash = "sha256:1a336b06eb2c3ace005f5f2ded8641d534c18798d64061f6ff11f79e1434126d", size = 21965, upload-time = "2025-01-10T18:51:11.848Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/c4/3f329b23d769fe7628a5fc57ad36956f1fb7132cf8837be6da762b197327/Flask_Migrate-4.1.0-py3-none-any.whl", hash = "sha256:24d8051af161782e0743af1b04a152d007bad9772b2bca67b7ec1e8ceeb3910d", size = 21237, upload-time = "2025-01-10T18:51:09.527Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add Flask-Migrate (Alembic) for database schema migrations
- Baseline revision consolidates all 16 legacy SQL migrations into one idempotent upgrade
- Sync model indexes with migrations (zero schema drift)
- Fix Media.time `Float(precision=2)` to `Float()`
- Fix `normalize_arabic_text()` to include newline collapsing

## Upgrade instructions (for release notes)

**Existing deployments (any version):**
```bash
uv sync
uv run flask db upgrade
```

**New installs:**
```bash
uv run flask create-db --create-exts
uv run flask db upgrade
```

That's it. The baseline migration is fully idempotent. It detects what's already applied and skips it.

## For contributors (going forward)
- Schema changes: `flask db migrate -m "description"`, review the generated file, commit
- Complex migrations: edit the generated file, use `op.execute()` for raw SQL
- Never use `flask create-db` for schema changes after this point