### PR TITLE
fix: avoid redundant GetObject after S3 put_object in direct upload

### DIFF
--- a/enferno/admin/views/media.py
+++ b/enferno/admin/views/media.py
@@ -293,9 +293,12 @@ def api_medias_upload() -> Response:
         filename = Media.generate_file_name(file.filename)
         # filepath = (Media.media_dir/filename).as_posix()
 
-        response = s3.Bucket(current_app.config["S3_BUCKET"]).put_object(Key=filename, Body=file)
+        obj = s3.Bucket(current_app.config["S3_BUCKET"]).put_object(Key=filename, Body=file)
 
-        etag = response.get()["ETag"].replace('"', "")
+        # obj is a boto3 s3.Object resource; .e_tag is populated from the PutObject
+        # response (wrapped in quotes per the S3 protocol). Reading it directly avoids
+        # an extra GetObject round trip that would otherwise stream the entire file back.
+        etag = obj.e_tag.strip('"')
 
         # check if file already exists
         if Media.query.filter(Media.etag == etag, Media.deleted == False).first():


### PR DESCRIPTION
## Summary

The direct-upload endpoint (`/api/media/upload/`) was issuing an extra `GetObject` call against S3 after every successful upload, streaming the full file body back over the network just to read the ETag header.

```python
response = s3.Bucket(...).put_object(Key=filename, Body=file)
etag = response.get()["ETag"].replace('"', "")
```

`put_object` on a boto3 `s3.Bucket` **resource** returns an `s3.Object` resource instance, not the raw PutObject response dict. `.get()` on that resource is a method that calls the `GetObject` API. So every upload via this path silently cost: 1 PUT (the real upload) + 1 GET (full body download of the file we just uploaded). The downloaded body was discarded.

The `s3.Object` resource already carries the ETag as `.e_tag`, populated directly from the PutObject response metadata with zero extra API calls. Switching to that eliminates the redundant round trip:

```python
obj = s3.Bucket(...).put_object(Key=filename, Body=file)
etag = obj.e_tag.strip('"')
```

Bit-for-bit compatible with existing data: both code paths produce the identical MD5 hex string, so no migration or dedup impact.

## Impact

For every direct-upload call to S3, this removes:
- 1 wasted GetObject API request
- A full download of the just-uploaded file (2x total network transfer)
- Perceived upload latency from waiting on that second round trip
- Potential egress cost if the app server and bucket are in different regions

## Verification

Tested against a live S3 bucket using a boto3 event hook to count real API calls, not just the final string value.

```
=== OLD code: obj.get()['ETag'].replace('"', '') ===
  PutObject calls: 1
  GetObject calls: 1   <-- the bug
  etag matches local MD5: True

=== NEW code: obj.e_tag.strip('"') ===
  PutObject calls: 1
  GetObject calls: 0   <-- fixed
  etag matches local MD5: True
```

Both code paths produced the identical etag `fe572aa83d504ff951fe3290beb6cfe5`, matching `hashlib.md5(body).hexdigest()` on the local buffer.

## Test plan

- [ ] Review the 2-line code change in `enferno/admin/views/media.py`
- [ ] Optional: upload a file via the admin UI with `FILESYSTEM_LOCAL=false` and confirm the returned `etag` still looks correct and dedup still works
- [ ] Confirm the stored `Media.etag` value is a 32-char MD5 hex string with no surrounding quotes (unchanged from before)