### PR TITLE
changelog: correct v4 entries to match the code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,18 +8,18 @@ Bayanat now uses Alembic (Flask-Migrate) for all schema changes. This replaces t
 
 ### OCR and Text Extraction
 
-- Unified OCR into provider-agnostic LLM support, replacing the Google Vision-only pipeline
-- Added PDF and DOCX text extraction (non-OCR)
-- Parallelized bulk OCR processing
-- Added text map visualization for OCR results
-- Added search and translation for extracted text
-- S3 storage backend support for OCR
+- New provider-agnostic OCR pipeline supporting Google Vision and any OpenAI-compatible LLM endpoint, replacing the prior inline Tesseract helper used during PDF import
+- New `Extraction` table stores OCR results as first-class data with edit history
+- Administrators switch OCR providers from the system administration dashboard (no restart required)
+- Added PDF and DOCX text extraction (multi-page PDFs with configurable page cap)
+- Parallelized bulk OCR processing with per-task isolation
+- Text Map overlay: opt-in UI that draws per-word bounding boxes on document images (Google Vision only; falls back to plain text for LLM providers)
+- Added search over extracted text (trigram-indexed) and on-demand translation
+- S3 storage backend support throughout the OCR pipeline
 
 ### Notifications
 
-- Redesigned notification system with dedicated database table
-- Email notification support with delivery tracking
-- Read status, urgency flags, and categorization (Update, Alert, etc.)
+- Notification drawer usability tweaks: hover-only mark-as-read icon, new mark-all-as-read button, subtler urgent-notification styling, wider drawer (#248)
 
 ### Search and UI
 
@@ -69,12 +69,11 @@ Bayanat now uses Alembic (Flask-Migrate) for all schema changes. This replaces t
 
 ### Data Model
 
-- ID number types: actor `id_number` converted from string to JSONB array with type tracking
+- New `Extraction` table for OCR results with edit history
 - Dynamic fields: bug fixes and core field seeding for search dialogs
-- Notification table with email tracking
-- Extraction table for OCR results with history
 - Media orientation field for image rotation support
 - Label constraints: self-parent prevention, sibling title uniqueness
+- Media orphan cleanup and per-entity etag uniqueness
 
 ### Breaking Changes
 


### PR DESCRIPTION
## Summary

Three items in the v4.0.0 `CHANGELOG.md` section were inaccurate when checked against the v3.0.0 tag. Correcting before we cut the release.

## The three errors

### 1. OCR pipeline framing
**Before:** "Unified OCR into provider-agnostic LLM support, replacing the Google Vision-only pipeline."

**Reality:** v3 had no Google Vision anywhere in the codebase. Its OCR was an inline Tesseract helper in \`enferno/data_import/utils/media_import.py\` used during PDF import. Verified by \`git grep google_vision v3.0.0\` (zero hits) and by reading the v3 media-import code path.

**After:** Section now correctly describes the v3 → v4 transition (Tesseract helper → provider-agnostic pipeline) and expands with the Extraction model, dashboard provider switching (#315), and the Text Map overlay that actually shipped.

### 2. Notifications
**Before:** "Redesigned notification system with dedicated database table. Email notification support with delivery tracking. Read status, urgency flags, and categorization."

**Reality:** \`enferno/admin/models/Notification.py\` is **identical at v3.0.0 and main** — 226 lines, zero commits touching the file since v3.0.0. The notification table, email delivery tracking, read status, urgency flags, and categorization all pre-existed v4. The only v4 change to notifications was PR #248, which adjusted drawer UI: hover-only mark-as-read icon, mark-all button, drawer width, urgent-notification color.

**After:** Replaced with an accurate one-liner describing the actual #248 changes.

### 3. Data Model — id_number JSONB conversion
**Before:** "ID number types: actor \`id_number\` converted from string to JSONB array with type tracking."

**Reality:** \`actor.id_number\` was already \`db.Column(JSONB, default=[], nullable=False)\` at v3.0.0. The declaration is line-for-line identical between v3 and main. The JSONB conversion happened before v3.0.0.

**After:** Removed the bullet. Also removed "Notification table with email tracking" (pre-existed v3) and added the missing media orphan cleanup / per-entity etag uniqueness entry from #311.

## Verification method

Every claim was checked against the v3.0.0 tag via \`git cat-file -e\`, \`git show v3.0.0:<path>\`, and file-by-file diffs between v3 and main.

## Test plan

- [x] \`git diff v3.0.0..HEAD -- CHANGELOG.md\` shows only accurate entries
- [x] No other files changed
- [x] Doc-only change, no code impact