### PR TITLE
Restore native pdf viewer

### DIFF
--- a/enferno/admin/templates/admin/activity.html
+++ b/enferno/admin/templates/admin/activity.html
@@ -194,6 +194,7 @@
 
     <script src="/static/js/components/MediaGrid.js"></script>
     <script src="/static/js/components/PdfViewer.js"></script>
+    <script src="/static/js/components/NativePdfViewer.js"></script>
     <script src="/static/js/components/DocxViewer.js"></script>
     <script src="/static/js/components/ImageViewer.js"></script>
     <script src="/static/js/components/InlineMediaRenderer.js"></script>
@@ -433,7 +434,8 @@
 
   app.component('MediaGrid', MediaGrid);
   app.component('PdfViewer', PdfViewer);
-        app.component('DocxViewer', DocxViewer);
+  app.component('NativePdfViewer', NativePdfViewer);
+  app.component('DocxViewer', DocxViewer);
   app.component('ImageViewer', ImageViewer);
   app.component('InlineMediaRenderer', InlineMediaRenderer);
 

--- a/enferno/admin/templates/admin/actors.html
+++ b/enferno/admin/templates/admin/actors.html
@@ -404,6 +404,7 @@
     <script src="/static/js/components/MediaTranscriptionDialog.js"></script>
 
     <script src="/static/js/components/PdfViewer.js"></script>
+    <script src="/static/js/components/NativePdfViewer.js"></script>
     <script src="/static/js/components/DocxViewer.js"></script>
     <script src="/static/js/components/SnapshotDialog.js"></script>
     <script src="/static/js/components/Visualization.js"></script>
@@ -1802,6 +1803,7 @@
         app.component('MediaThumbnail', MediaThumbnail);
         app.component('Visualization', Visualization);
         app.component('PdfViewer', PdfViewer);
+        app.component('NativePdfViewer', NativePdfViewer);
         app.component('DocxViewer', DocxViewer);
         app.component('SnapshotDialog', SnapshotDialog);
         app.component('PreviewCard', PreviewCard);

--- a/enferno/admin/templates/admin/bulletins.html
+++ b/enferno/admin/templates/admin/bulletins.html
@@ -430,6 +430,7 @@
     <script src="/static/js/components/InlineMediaRenderer.js"></script>
     <script src="/static/js/components/ImageViewer.js"></script>
     <script src="/static/js/components/PdfViewer.js"></script>
+    <script src="/static/js/components/NativePdfViewer.js"></script>
     <script src="/static/js/components/DocxViewer.js"></script>
     <script src="/static/js/components/SnapshotDialog.js"></script>
     <script src="/static/js/components/Visualization.js"></script>
@@ -1793,6 +1794,7 @@
         app.component('MediaThumbnail', MediaThumbnail);
         app.component('Visualization', Visualization);
         app.component('PdfViewer', PdfViewer);
+        app.component('NativePdfViewer', NativePdfViewer);
         app.component('DocxViewer', DocxViewer);
         app.component('SnapshotDialog', SnapshotDialog);
         app.component('PreviewCard', PreviewCard);

--- a/enferno/admin/templates/admin/incidents.html
+++ b/enferno/admin/templates/admin/incidents.html
@@ -361,6 +361,7 @@
     <script src="/static/js/components/FieldRenderer.js"></script>
 
     <script src="/static/js/components/PdfViewer.js"></script>
+    <script src="/static/js/components/NativePdfViewer.js"></script>
     <script src="/static/js/components/DocxViewer.js"></script>
     <script src="/static/js/components/ImageViewer.js"></script>
     <script src="/static/js/components/InlineMediaRenderer.js"></script>
@@ -1562,6 +1563,7 @@
         app.component('MediaThumbnail', MediaThumbnail);
         app.component('Visualization', Visualization);
         app.component('PdfViewer', PdfViewer);
+        app.component('NativePdfViewer', NativePdfViewer);
         app.component('DocxViewer', DocxViewer);
         app.component('ImageViewer', ImageViewer);
         app.component('InlineMediaRenderer', InlineMediaRenderer);

--- a/enferno/admin/templates/admin/media-dashboard.html
+++ b/enferno/admin/templates/admin/media-dashboard.html
@@ -234,6 +234,7 @@
     <script src="/static/js/components/OcrTextLayer.js"></script>
     <script src="/static/js/components/MediaTranscriptionDialog.js"></script>
     <script src="/static/js/components/PdfViewer.js"></script>
+    <script src="/static/js/components/NativePdfViewer.js"></script>
     <script src="/static/js/components/DocxViewer.js"></script>
     <script src="/static/js/components/ImageViewer.js"></script>
     <script src="/static/js/components/UniField.js"></script>
@@ -537,6 +538,7 @@
         app.component('OcrTextLayer', OcrTextLayer);
         app.component('MediaTranscriptionDialog', MediaTranscriptionDialog);
         app.component('PdfViewer', PdfViewer);
+        app.component('NativePdfViewer', NativePdfViewer);
         app.component('DocxViewer', DocxViewer);
         app.component('ImageViewer', ImageViewer);
         app.component('UniField', UniField);

--- a/enferno/app.py
+++ b/enferno/app.py
@@ -242,7 +242,7 @@ def register_talisman(app):
         # Other security headers
         force_https=app.config.get("FORCE_HTTPS", False),  # Don't force in dev
         force_https_permanent=False,
-        frame_options="DENY",
+        frame_options="SAMEORIGIN",
         strict_transport_security=app.config.get("FORCE_HTTPS", False),
         strict_transport_security_max_age=31536000,  # 1 year
         strict_transport_security_include_subdomains=True,

--- a/enferno/data_import/templates/import-log.html
+++ b/enferno/data_import/templates/import-log.html
@@ -116,7 +116,8 @@
 <script src="/static/js/components/RelatedIncidentsCard.js"></script>
 
 <script src="/static/js/components/PdfViewer.js"></script>
-    <script src="/static/js/components/DocxViewer.js"></script>
+<script src="/static/js/components/NativePdfViewer.js"></script>
+<script src="/static/js/components/DocxViewer.js"></script>
 <script src="/static/js/components/ImageViewer.js"></script>
 <script src="/static/js/components/InlineMediaRenderer.js"></script>
 <script src="/static/js/components/GlobalMap.js"></script>
@@ -306,6 +307,7 @@
         app.component('IncidentResult', IncidentResult);
         app.component('UniField', UniField);
         app.component('PdfViewer', PdfViewer);
+        app.component('NativePdfViewer', NativePdfViewer);
         app.component('DocxViewer', DocxViewer);
         app.component('ImageViewer', ImageViewer);
         app.component('InlineMediaRenderer', InlineMediaRenderer);

--- a/enferno/deduplication/templates/deduplication.html
+++ b/enferno/deduplication/templates/deduplication.html
@@ -141,8 +141,8 @@
 <script src="/static/js/components/PopDateTimeField.js"></script>
 
 <script src="/static/js/components/MediaGrid.js"></script>
-<script src="/static/js/components/PdfViewer.js"></script>
-    <script src="/static/js/components/DocxViewer.js"></script>
+<script src="/static/js/components/NativePdfViewer.js"></script>
+<script src="/static/js/components/DocxViewer.js"></script>
 <script src="/static/js/components/ImageViewer.js"></script>
 <script src="/static/js/components/InlineMediaRenderer.js"></script>
 
@@ -349,7 +349,8 @@
 
     app.component('MediaGrid', MediaGrid);
     app.component('PdfViewer', PdfViewer);
-        app.component('DocxViewer', DocxViewer);
+    app.component('NativePdfViewer', NativePdfViewer);
+    app.component('DocxViewer', DocxViewer);
     app.component('ImageViewer', ImageViewer);
     app.component('InlineMediaRenderer', InlineMediaRenderer);
 

--- a/enferno/deduplication/templates/deduplication.html
+++ b/enferno/deduplication/templates/deduplication.html
@@ -141,6 +141,7 @@
 <script src="/static/js/components/PopDateTimeField.js"></script>
 
 <script src="/static/js/components/MediaGrid.js"></script>
+<script src="/static/js/components/PdfViewer.js"></script>
 <script src="/static/js/components/NativePdfViewer.js"></script>
 <script src="/static/js/components/DocxViewer.js"></script>
 <script src="/static/js/components/ImageViewer.js"></script>

--- a/enferno/export/templates/export-dashboard.html
+++ b/enferno/export/templates/export-dashboard.html
@@ -116,6 +116,7 @@
     <script src="/static/js/components/InlineMediaRenderer.js"></script>
     <script src="/static/js/components/ImageViewer.js"></script>
     <script src="/static/js/components/PdfViewer.js"></script>
+    <script src="/static/js/components/NativePdfViewer.js"></script>
     <script src="/static/js/components/DocxViewer.js"></script>
 
     <script src="/static/js/components/BulletinResult.js"></script>
@@ -350,6 +351,7 @@
         app.component('InlineMediaRenderer', InlineMediaRenderer);
         app.component('ImageViewer', ImageViewer);
         app.component('PdfViewer', PdfViewer);
+        app.component('NativePdfViewer', NativePdfViewer);
         app.component('DocxViewer', DocxViewer);
 
         app.use(router).use(vuetify);

--- a/enferno/static/js/components/InlineMediaRenderer.js
+++ b/enferno/static/js/components/InlineMediaRenderer.js
@@ -24,6 +24,10 @@ const InlineMediaRenderer = Vue.defineComponent({
         type: Number,
         default: 0,
       },
+      usePdfCanvasRenderer: {
+        type: Boolean,
+        default: false,
+      },
     },
     emits: ['ready', 'fullscreen', 'close', 'orientation-changed'],
     data: () => ({
@@ -159,12 +163,13 @@ const InlineMediaRenderer = Vue.defineComponent({
             ref="playerContainer"
             class="h-100"
           ></div>
-          <pdf-viewer ref="pdfViewer" v-if="mediaType === 'pdf'" :media="media" :media-type="mediaType" class="w-100 h-100"></pdf-viewer>
-          <image-viewer ref="imageViewer" v-if="mediaType === 'image'" :initial-orientation="initialOrientation" :media="media" :media-type="mediaType" class="h-100" @orientation-changed="$emit('orientation-changed', $event)"></image-viewer>
-          <docx-viewer ref="docxViewer" v-if="mediaType === 'docx'" :media="media" class="w-100 h-100"></docx-viewer>
+          <pdf-viewer ref="pdfViewer" v-else-if="usePdfCanvasRenderer && mediaType === 'pdf'" :media="media" :media-type="mediaType" class="w-100 h-100"></pdf-viewer>
+          <native-pdf-viewer ref="pdfViewer" v-else-if="mediaType === 'pdf'" :media="media" :media-type="mediaType" class="w-100 h-100"></native-pdf-viewer>
+          <image-viewer ref="imageViewer" v-else-if="mediaType === 'image'" :initial-orientation="initialOrientation" :media="media" :media-type="mediaType" class="h-100" @orientation-changed="$emit('orientation-changed', $event)"></image-viewer>
+          <docx-viewer ref="docxViewer" v-else-if="mediaType === 'docx'" :media="media" class="w-100 h-100"></docx-viewer>
 
           <!-- Fallback for unknown file types -->
-          <div v-if="mediaType === 'unknown'" class="h-100 d-flex flex-column align-center justify-center bg-grey-lighten-2">
+          <div v-else-if="mediaType === 'unknown'" class="h-100 d-flex flex-column align-center justify-center bg-grey-lighten-2">
             <v-icon size="64" color="grey">mdi-file-download</v-icon>
             <div class="text-h6 mt-4 text-medium-emphasis">{{ translations.previewNotAvailable_ }}</div>
             <div class="text-caption text-medium-emphasis">{{ media.filename }}</div>

--- a/enferno/static/js/components/MediaTranscriptionDialog.js
+++ b/enferno/static/js/components/MediaTranscriptionDialog.js
@@ -295,6 +295,7 @@ const MediaTranscriptionDialog = Vue.defineComponent({
                     <div v-else class="position-relative">
                       <div>
                         <inline-media-renderer
+                          use-pdf-canvas-renderer
                           renderer-id="ocr-dialog"
                           :initial-orientation="media?.orientation || 0"
                           :media="$root.expandedByRenderer?.['ocr-dialog']?.media"

--- a/enferno/static/js/components/NativePdfViewer.js
+++ b/enferno/static/js/components/NativePdfViewer.js
@@ -1,0 +1,39 @@
+const NativePdfViewer = Vue.defineComponent({
+  props: ['media', 'mediaType'],
+  data: () => {
+    return {
+      translations: window.translations,
+      fullscreen: false,
+    };
+  },
+  methods: {
+    requestFullscreen() {
+      this.fullscreen = true;
+    },
+  },
+  template: `
+    <div>
+      <v-dialog
+        v-model="fullscreen"
+        fullscreen
+      >
+        <v-card class="overflow-hidden">
+          <v-toolbar color="dark-primary">
+              <v-toolbar-title>{{ translations.preview_ }}</v-toolbar-title>
+              <v-spacer></v-spacer>
+          
+              <template #append>
+                  <v-btn icon="mdi-close" @click.stop.prevent="fullscreen = false"></v-btn>
+              </template>
+          </v-toolbar>
+      
+          <v-card-text class="pa-0" style="height: calc(100vh - 64px);">
+            <iframe :src="media?.s3url" class="w-100 h-100" allow="fullscreen" allow-fullscreen></iframe>
+          </v-card-text>
+        </v-card>
+      </v-dialog>
+
+      <iframe :src="media?.s3url" class="w-100 h-100"   allowfullscreen allow-fullscreen></iframe>
+    </div>
+    `,
+});


### PR DESCRIPTION
## Description
Brings back the native PDF viewer (iframe) for normal viewing and keeps the canvas viewer for OCR.

Default: native viewer (text selection, search, zoom, etc.)
OCR dialog: still uses canvas renderer
No changes to OCR pipeline

## How to Test
Open a PDF → verify it uses the browser native pdf viewer with their own tools (marker, zoom, etc)
Open OCR dialog → verify pdf canvas viewer + OCR still work
Check fullscreen works
Check images and DOCX still work

## Jira ID (if applicable)
[BYNT-1679](https://syriajustice.atlassian.net/browse/BYNT-1679)


[BYNT-1679]: https://syriajustice.atlassian.net/browse/BYNT-1679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ