### PR TITLE
v4.0.1: fix bulk OCR celery queue routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v4.0.1
+
+### Fixed
+
+- Bulk OCR: celery worker now consumes the `ocr` queue. The systemd unit written by the installer was only subscribing to the default `celery` queue, so tasks dispatched by bulk OCR (UI and `flask ocr process`) silently piled up in Redis. Single-media OCR was not affected. Existing installs can fix in place by adding `-Q celery,ocr` to `ExecStart` in `/etc/systemd/system/bayanat-celery.service`, then `systemctl daemon-reload && systemctl restart bayanat-celery`.
+
 ## v4.0.0
 
 ### Database Migrations (Alembic)

--- a/bayanat
+++ b/bayanat
@@ -305,7 +305,7 @@ User=$APP_USER
 Group=$APP_USER
 WorkingDirectory=$CURRENT_LINK
 EnvironmentFile=$SHARED_DIR/.env
-ExecStart=$CURRENT_LINK/.venv/bin/celery -A enferno.tasks worker --autoscale 2,5 -B
+ExecStart=$CURRENT_LINK/.venv/bin/celery -A enferno.tasks worker --autoscale 2,5 -B -Q celery,ocr
 Restart=always
 RestartSec=3
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bayanat"
-version = "4.0.0"
+version = "4.0.1"
 description = "Open source data management solution for processing human rights violations and war crimes data"
 readme = "README.md"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION
## Summary

- Installer's systemd unit for `bayanat-celery` only subscribed to the default `celery` queue, but `ocr_single` tasks route to a dedicated `ocr` queue (`enferno/tasks/__init__.py`).
- Any bulk OCR dispatched via the admin UI (`POST /admin/api/ocr/bulk`) or the `flask ocr process` CLI piled up in Redis with no consumer.
- Single-media OCR (per-item UI button / `flask ocr extract`) was unaffected — it takes a sync path through `process_media_extraction_task()`.

## Fix

Add `-Q celery,ocr` to the `ExecStart` line so the worker consumes both queues.

## Affected versions

- v4.0.0 (GA install command ships the broken unit).

## Upgrade path

### Fresh install

Nothing special — new installs get the fixed unit.

### Existing v4.0.0 installs (in-place patch, no reinstall needed)

```
sudo sed -i.bak 's|worker --autoscale 2,5 -B$|& -Q celery,ocr|' /etc/systemd/system/bayanat-celery.service
sudo systemctl daemon-reload
sudo systemctl restart bayanat-celery
```

Verify with `sudo journalctl -u bayanat-celery --since "30 seconds ago" | grep queues` — should list both `celery` and `ocr`.

## Test plan

- [x] Reproduced on auto-update-simplified deployment: 6 tasks stuck in `ocr` queue with 0 processed, worker idle.
- [x] Applied the same fix to prod2 manually: queue drains, `ocr_single` tasks processed end-to-end via Google Vision API.
- [x] All 4 test media processed successfully (confidence 24-98%, zero failures).
- [ ] Tag `v4.0.1` after merge and update docs installer URL to pin v4.0.1.