### PR TITLE
Feat/custom s3 endpoint

### DIFF
--- a/enferno/admin/views/media.py
+++ b/enferno/admin/views/media.py
@@ -103,6 +103,7 @@ def _media_url(media_file):
         aws_access_key_id=current_app.config["AWS_ACCESS_KEY_ID"],
         aws_secret_access_key=current_app.config["AWS_SECRET_ACCESS_KEY"],
         region_name=current_app.config["AWS_REGION"],
+        endpoint_url=current_app.config.get("S3_ENDPOINT"),
     )
     return s3.generate_presigned_url(
         "get_object",
@@ -237,6 +238,7 @@ def api_medias_chunk() -> Response:
                 aws_access_key_id=current_app.config["AWS_ACCESS_KEY_ID"],
                 aws_secret_access_key=current_app.config["AWS_SECRET_ACCESS_KEY"],
                 region_name=current_app.config["AWS_REGION"],
+                endpoint_url=current_app.config.get("S3_ENDPOINT"),
             )
             s3.Bucket(current_app.config["S3_BUCKET"]).upload_file(filepath, filename)
             # Clean up file if s3 mode is selected
@@ -302,6 +304,7 @@ def api_medias_upload() -> Response:
             "s3",
             aws_access_key_id=current_app.config["AWS_ACCESS_KEY_ID"],
             aws_secret_access_key=current_app.config["AWS_SECRET_ACCESS_KEY"],
+            endpoint_url=current_app.config.get("S3_ENDPOINT"),
         )
 
         # final file
@@ -355,6 +358,7 @@ def serve_media(
             aws_access_key_id=current_app.config["AWS_ACCESS_KEY_ID"],
             aws_secret_access_key=current_app.config["AWS_SECRET_ACCESS_KEY"],
             region_name=current_app.config["AWS_REGION"],
+            endpoint_url=current_app.config.get("S3_ENDPOINT"),
         )
 
         # allow generation of s3 urls for a short period while the media is not created

--- a/enferno/settings.py
+++ b/enferno/settings.py
@@ -206,6 +206,7 @@ class Config(object):
     AWS_SECRET_ACCESS_KEY = manager.get_config("AWS_SECRET_ACCESS_KEY")
     S3_BUCKET = manager.get_config("S3_BUCKET")
     AWS_REGION = manager.get_config("AWS_REGION")
+    S3_ENDPOINT = manager.get_config("S3_ENDPOINT")
 
     # i18n
     LANGUAGES = {

--- a/enferno/utils/config_utils.py
+++ b/enferno/utils/config_utils.py
@@ -41,6 +41,7 @@ class ConfigManager:
             "AWS_SECRET_ACCESS_KEY": "",
             "S3_BUCKET": "",
             "AWS_REGION": "",
+            "S3_ENDPOINT": "",  
             "ACCESS_CONTROL_RESTRICTIVE": False,
             "AC_USERS_CAN_RESTRICT_NEW": False,
             "MEDIA_ALLOWED_EXTENSIONS": [
@@ -190,6 +191,7 @@ class ConfigManager:
             "AWS_SECRET_ACCESS_KEY": "AWS Secret Access Key",
             "S3_BUCKET": "S3 Bucket",
             "AWS_REGION": "AWS Region",
+            "S3_ENDPOINT": "S3 Endpoint URL",
             "ACCESS_CONTROL_RESTRICTIVE": "Restrictive Access Control",
             "AC_USERS_CAN_RESTRICT_NEW": "Users Can Restrict New Items",
             "MEDIA_ALLOWED_EXTENSIONS": "Media Upload Allowed File Extensions",
@@ -299,6 +301,7 @@ class ConfigManager:
             "AWS_SECRET_ACCESS_KEY": ConfigManager.MASK_STRING if cfg.AWS_SECRET_ACCESS_KEY else "",
             "S3_BUCKET": cfg.S3_BUCKET,
             "AWS_REGION": cfg.AWS_REGION,
+            "S3_ENDPOINT": cfg.S3_ENDPOINT,  
             "ACCESS_CONTROL_RESTRICTIVE": cfg.ACCESS_CONTROL_RESTRICTIVE,
             "AC_USERS_CAN_RESTRICT_NEW": cfg.AC_USERS_CAN_RESTRICT_NEW,
             "MEDIA_ALLOWED_EXTENSIONS": cfg.MEDIA_ALLOWED_EXTENSIONS,


### PR DESCRIPTION
# Adding a custom S3 endpoint support for non-AWS providers

While deploying Bayanat for a human rights project, we needed to use OVH Object Storage instead of AWS. boto3 works fine with any other providor but without an endpoint, it silently goes to Amazon and rejects everything.

The codebase had no way to configure this. Three small changes fix it:

## Changes

**1) `enferno/utils/config_utils.py`**:  `S3_ENDPOINT` needs to be added in 3 places inside this file:
 
- **Default values block**:  so the key exists with an empty default:
```python
"AWS_REGION": "",
"S3_ENDPOINT": "",
```
 
- **UI labels block**:  so it shows up correctly in the setup wizard:
```python
"AWS_REGION": "AWS Region",
"S3_ENDPOINT": "S3 Endpoint URL",
```
 
- **Config reader block**:  so the current value gets read back:
```python
"AWS_REGION": cfg.AWS_REGION,
"S3_ENDPOINT": cfg.S3_ENDPOINT,
```

**2) `enferno/settings.py`** — one line added to load `S3_ENDPOINT` into Flask's `app.config`:
```python
S3_ENDPOINT = manager.get_config("S3_ENDPOINT")
```
Without this, `current_app.config.get("S3_ENDPOINT")` returns `None` everywhere even if `config.json` has it.


**3) `enferno/admin/views/media.py`**: added `endpoint_url` to all 4 boto3 calls (`_media_url`, `api_medias_chunk`, `api_medias_upload`, `serve_media`):
```python
endpoint_url=current_app.config.get("S3_ENDPOINT")
```

## Backward compatibility

If `S3_ENDPOINT` is not set, `config.get()` returns `None` and boto3 falls back to AWS as before, nothing breaks for existing deployments.
