### PR TITLE
Fix media import uploads for ETL file types

### DIFF
--- a/enferno/data_import/templates/media-import.html
+++ b/enferno/data_import/templates/media-import.html
@@ -388,9 +388,22 @@
                     thumbnailHeight: 80,
                     parallelUploads: 1,
                     maxFilesize: mediaUploadMaxFileSize,
-                    // Signals the chunk endpoint to apply the Admin-only
-                    // extended extension list (ETL_VID_EXT).
-                    params: { source: 'import' },
+                    params(files, xhr, chunk) {
+                        // Signals the chunk endpoint to apply the Admin-only
+                        // extended extension list (ETL_VID_EXT).
+                        const params = { source: 'import' };
+
+                        if (chunk) {
+                            params.dzuuid = chunk.file.upload.uuid;
+                            params.dzchunkindex = chunk.index;
+                            params.dztotalfilesize = chunk.file.size;
+                            params.dzchunksize = this.options.chunkSize;
+                            params.dztotalchunkcount = chunk.file.upload.totalChunkCount;
+                            params.dzchunkbyteoffset = chunk.index * this.options.chunkSize;
+                        }
+
+                        return params;
+                    },
                 },
 
 


### PR DESCRIPTION
## Description
Adds the `source: "import"` field to media import chunk upload requests while preserving Dropzone’s chunk metadata.

Without the import source flag, the backend validates uploads against MEDIA_ALLOWED_EXTENSIONS instead of ETL_VID_EXT, causing allowed media import file types like .mov to fail with 415.

## How to Test

1. Go to /import/media/.
2. Click “Upload files”.
3. Select a file type allowed by ETL_VID_EXT but not MEDIA_ALLOWED_EXTENSIONS, such as .mov.
4. Confirm the upload succeeds and does not return 415.
5. In DevTools Network, confirm /admin/api/media/chunk includes source: import plus chunk fields like dzuuid and dzchunkindex.
6. Confirm normal actor/bulletin media uploads still validate against MEDIA_ALLOWED_EXTENSIONS.

## Jira ID (if applicable)
[BYNT-1695](https://syriajustice.atlassian.net/browse/BYNT-1695)


[BYNT-1695]: https://syriajustice.atlassian.net/browse/BYNT-1695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ