### PR TITLE
fix(config): allow 5-char file extensions in allowed lists

### DIFF
--- a/enferno/admin/validation/models.py
+++ b/enferno/admin/validation/models.py
@@ -1704,7 +1704,7 @@ class ConfigValidationModel(StrictValidationModel):
                     raise ValueError(
                         "MEDIA_ALLOWED_EXTENSIONS and SHEETS_ALLOWED_EXTENSIONS must be lists of strings"
                     )
-                if len(ext) < 2 or len(ext) > 4:
+                if len(ext) < 2 or len(ext) > 5:
                     raise ValueError(
                         "Invalid value for MEDIA_ALLOWED_EXTENSIONS or SHEETS_ALLOWED_EXTENSIONS"
                     )


### PR DESCRIPTION
## Summary
- The `ConfigValidationModel` validator for `MEDIA_ALLOWED_EXTENSIONS` and `SHEETS_ALLOWED_EXTENSIONS` rejected any extension shorter than 2 or longer than 4 characters.
- This blocked legitimate 5-char extensions like `mhtml` and `xhtml` from being added via System Administration, surfacing as `Invalid value for field` in the UI.
- Bumps the per-extension upper bound from 4 to 5. Upload-time allowlist enforcement in `enferno/admin/views/media.py` is unchanged.

## Test plan
- [x] Open System Administration → add `mhtml` to Media Upload Allowed File Extensions and save successfully.
- [x] Confirm 1-char or 6+-char values are still rejected.
- [x] Confirm a media upload using the newly-added extension succeeds.