### PR TITLE
fix(uwsgi): wire touch-reload so admin Reload button actually reloads

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -7,6 +7,7 @@ threads=2
 http=127.0.0.1:5000
 vacuum=true
 buffer-size=8192
+touch-reload=reload.ini
 harakiri=360
 harakiri-verbose=true
 ;offload-threads=2


### PR DESCRIPTION
## Summary
- `enferno/tasks/maintenance.py::reload_app()` touches `<project_root>/reload.ini` to trigger a uWSGI graceful reload after a config change, but `uwsgi.ini` had no `touch-reload` directive, so uWSGI was never watching that file.
- The admin **System Administration → Reload** action returned "Reloading Bayanat" while the running workers kept their previous in-memory config. Any edit to `config.json` (e.g. adding a value to `MEDIA_ALLOWED_EXTENSIONS`) appeared to save successfully but did not take effect until a full `systemctl restart bayanat`.
- Adds `touch-reload=reload.ini` to `uwsgi.ini`. uWSGI's working directory is the project root, so the relative path resolves to the same location `reload_app()` writes to.

## Test plan
- [x] Start the app under uWSGI, edit a value in System Administration, click **Reload**, and confirm uWSGI logs `gracefully (RE)spawned uWSGI master process` and the new value is live without a `systemctl restart`.
- [x] Confirm Flask dev server (`flask run`) is unaffected (the maintenance helper already no-ops when the `uwsgi` module isn't importable).