### PR TITLE
docs(v4.0.2): extend changelog with post-#324 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,20 @@
 ### Security
 
 - Bumped vulnerable dependencies in `uv.lock`:
-  - `lxml` 6.0.2 → 6.1.0 ([GHSA-pp7h-53gx-mx7r](https://github.com/advisories/GHSA-pp7h-53gx-mx7r), high — XXE in `iterparse`/`ETCompatXMLParser`)
-  - `pillow` 12.1.1 → 12.2.0 ([GHSA-2vfv-wwj6-7q47](https://github.com/advisories/GHSA-2vfv-wwj6-7q47), high — FITS GZIP decompression bomb)
-  - `pypdf` 6.10.0 → 6.10.2 (medium — three RAM-exhaustion advisories)
-  - `python-dotenv` 1.2.1 → 1.2.2 (medium — symlink-following in `set_key`)
-  - `Mako` 1.3.10 → 1.3.11 (medium — path traversal in `TemplateLookup`)
-  - `pytest` 9.0.2 → 9.0.3 (dev, medium — vulnerable `tmpdir` handling)
+  - `urllib3` 2.6.3 → 2.7.0 (high, [GHSA-48p4-8xcf-vxj5](https://github.com/advisories/GHSA-48p4-8xcf-vxj5) sensitive headers forwarded across origins in proxied redirects; [GHSA-pq67-6m6q-mj2v](https://github.com/advisories/GHSA-pq67-6m6q-mj2v) decompression-bomb bypass in streaming API)
+  - `lxml` 6.0.2 → 6.1.0 ([GHSA-pp7h-53gx-mx7r](https://github.com/advisories/GHSA-pp7h-53gx-mx7r), high, XXE in `iterparse`/`ETCompatXMLParser`)
+  - `pillow` 12.1.1 → 12.2.0 ([GHSA-2vfv-wwj6-7q47](https://github.com/advisories/GHSA-2vfv-wwj6-7q47), high, FITS GZIP decompression bomb)
+  - `pypdf` 6.10.0 → 6.10.2 (medium, three RAM-exhaustion advisories)
+  - `python-dotenv` 1.2.1 → 1.2.2 (medium, symlink-following in `set_key`)
+  - `Mako` 1.3.10 → 1.3.11 (medium, path traversal in `TemplateLookup`)
+  - `pytest` 9.0.2 → 9.0.3 (dev, medium, vulnerable `tmpdir` handling)
+- Bumped `axios` 1.15.0 → 1.16.0 (frontend dep, [GHSA-4hjh-wcwx-04pq](https://github.com/advisories/GHSA-4hjh-wcwx-04pq) DoS via large response).
+
+### Fixed
+
+- Admin "Reload" button now actually reloads the app. `uwsgi.ini` was missing the `touch-reload=reload.ini` directive, so the maintenance task touched the file with no effect on the running workers. After upgrading, existing installs should also append `touch-reload=reload.ini` to `/bayanat/uwsgi.ini` if they have local edits to that file.
+- Allowed-extensions validator now accepts up to 5-character file extensions (previously capped at 4 characters). The cap rejected valid extensions like `mhtml`, `xhtml`, and `jhtml` from `MEDIA_ALLOWED_EXTENSIONS` and `SHEETS_ALLOWED_EXTENSIONS`.
+- Restored the native browser PDF viewer for inline preview.
 
 ## v4.0.1
 


### PR DESCRIPTION
## Summary

Updates the existing v4.0.2 changelog section to cover everything that has landed since #324 (the v4.0.2 prep PR), so the entry reflects what will actually ship in the v4.0.2 release.

## Added to v4.0.2 entry

**Security**
- urllib3 2.6.3 -> 2.7.0 (high, 2 GHSAs)
- axios 1.15.0 -> 1.16.0 (DoS)

**Fixed**
- Admin Reload button now triggers an actual uWSGI reload (touch-reload wiring)
- Allowed-extensions validator now accepts up to 5-character extensions
- Restored native browser PDF viewer

## Post-merge

Once this lands, tag `v4.0.2` on the resulting main commit and publish the GitHub release.

## Test plan

- [x] Changelog renders correctly (markdown sanity check)
- [x] No code changes, docs only