### PR TITLE
fix(export): stop leaking internal description in public archive export

### DIFF
--- a/enferno/commands.py
+++ b/enferno/commands.py
@@ -803,8 +803,9 @@ MEDIA_DIR = Media.media_dir
 def serialize_bulletin(bulletin):
     """Serialize a bulletin for the public archive export.
 
-    Includes only public-facing fields. Strips workflow, assignment,
-    review, and internal metadata.
+    Includes only public-facing fields. The internal ``description`` is
+    never exported; only the SJAC-authored ``public_description`` goes out.
+    Strips workflow, assignment, review, and internal metadata.
     """
     labels = [
         {"id": l.id, "title": l.title, "title_ar": l.title_ar, "verified": l.verified}
@@ -911,7 +912,6 @@ def serialize_bulletin(bulletin):
         "id": bulletin.id,
         "title": bulletin.title,
         "title_ar": bulletin.title_ar,
-        "description": bulletin.description,
         "public_description": bulletin.public_description,
         "source_link": bulletin.source_link,
         "publish_date": DateHelper.serialize_datetime(bulletin.publish_date),


### PR DESCRIPTION
## Problem

The public archive export (\`flask export public\`, added in #345) serialized **both** the internal \`description\` and the SJAC-authored \`public_description\` into \`documents.json\`. The internal \`description\` holds staff notes that are not meant for public consumption, so it should never leave Bayanat.

## Fix

Drop \`description\` from \`serialize_bulletin()\`. Only \`public_description\` is exported now.

## Notes

- The archive import side reads the field with \`doc.get("description")\`, so a missing key does not break import (it just stores NULL).
- Follow-ups for a separate pass: the archive's \`EXPORT_SCHEMA.md\` still lists \`description\` as required and the archive schema/FTS still index it. Those should be reconciled, and redaction of \`public_description\` itself is tracked separately.