### PR TITLE
Fix frontend stored XSS rendering paths

### DIFF
--- a/enferno/static/js/common/config.js
+++ b/enferno/static/js/common/config.js
@@ -377,8 +377,8 @@ function getInfraMessage(status) {
       return Object.entries(errors).map(([field, message]) => {
         const fieldName = field.startsWith('item.') ? field.slice(5) : field;
         const label = fieldName.includes('__root__') ? 'Validation Error' : fieldName;
-        return `<span class="font-weight-bold text-red">[${label}]</span>: ${message}`;
-      }).join('<br />') || 'An error occurred.';
+        return `[${label}]: ${message}`;
+      }).join('\n') || 'An error occurred.';
     }
 
     if (response?.data?.message) {

--- a/enferno/static/js/common/config.js
+++ b/enferno/static/js/common/config.js
@@ -118,6 +118,18 @@ function isValidLength(value, limit, type) {
     return type === "max" ? length <= limit : length >= limit;
 }
 
+function escapeHtml(value) {
+  const entityMap = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  };
+
+  return String(value ?? '').replace(/[&<>"']/g, char => entityMap[char]);
+}
+
 function scrollToFirstError() {
   const wrapper = document.querySelector(".v-input--error");
   if (!wrapper) return;

--- a/enferno/static/js/components/EventsSection.js
+++ b/enferno/static/js/components/EventsSection.js
@@ -49,7 +49,7 @@ const EventsSection = Vue.defineComponent({
       if (!hasTitleOrType) missing.push(this.translations.titleOrTypeRequired_);
 
       if (missing.length > 0) {
-        this.$root.showSnack(missing.join('<br />'));
+        this.$root.showSnack(missing.join('\n'));
         return false;
       }
 

--- a/enferno/static/js/components/GeoLocations.js
+++ b/enferno/static/js/components/GeoLocations.js
@@ -129,7 +129,7 @@ const GeoLocations = Vue.defineComponent({
                         {{ loc.lat.toFixed(4) }} , {{ loc.lng.toFixed(4) }}
                       </div>
 
-                      <div v-if="loc.comment" class="comments pa-3 mt-2" v-html="loc.comment">
+                      <div v-if="loc.comment" class="comments pa-3 mt-2" v-text="loc.comment">
 
                       </div>
 

--- a/enferno/static/js/components/GlobalMap.js
+++ b/enferno/static/js/components/GlobalMap.js
@@ -70,43 +70,54 @@ const GlobalMap = Vue.defineComponent({
   },
 
   methods: {
+    escapeHtml(value) {
+      const entityMap = {
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;',
+      };
+
+      return String(value ?? '').replace(/[&<>"']/g, char => entityMap[char]);
+    },
     generatePopupContent(loc) {
       const t = this.translations;
 
       // Dates
       const dates = [];
-      if (loc.from_date) dates.push(`<span class="chip">${this.$root.formatDate(loc.from_date, loc.from_date.includes('T00:00') ? this.$root.dateFormats.standardDate : this.$root.dateFormats.standardDatetime)}</span>`);
+      if (loc.from_date) dates.push(`<span class="chip">${this.escapeHtml(this.$root.formatDate(loc.from_date, loc.from_date.includes('T00:00') ? this.$root.dateFormats.standardDate : this.$root.dateFormats.standardDatetime))}</span>`);
       if (loc.from_date && loc.to_date) dates.push(`<i class="mdi mdi-arrow-right mr-1">`);
-      if (loc.to_date) dates.push(`<span></i>${this.$root.formatDate(loc.to_date, loc.to_date.includes('T00:00') ? this.$root.dateFormats.standardDate : this.$root.dateFormats.standardDatetime)}</span>`);
+      if (loc.to_date) dates.push(`<span></i>${this.escapeHtml(this.$root.formatDate(loc.to_date, loc.to_date.includes('T00:00') ? this.$root.dateFormats.standardDate : this.$root.dateFormats.standardDatetime))}</span>`);
 
       const estimated = loc.estimated
-        ? `<i class="mdi mdi-calendar-question mr-1" title="${t.timingForThisEventIsEstimated_}"></i>`
+        ? `<i class="mdi mdi-calendar-question mr-1" title="${this.escapeHtml(t.timingForThisEventIsEstimated_)}"></i>`
         : '<i class="mdi mdi-calendar-clock mr-1"></i>';
 
       const dateRange = dates.length ? `<div class="d-flex">${estimated} ${dates.join(' ')}</div>` : '';
 
-      const parentId = loc?.parentId && loc?.show_parent_id ? `<div><i class="mdi mdi-link mr-1"></i>${loc.parentId}</div>` : '';
+      const parentId = loc?.parentId && loc?.show_parent_id ? `<div><i class="mdi mdi-link mr-1"></i>${this.escapeHtml(loc.parentId)}</div>` : '';
 
       // Copy button using data-copy instead of onclick
       const copyCoordsBtn = (Number.isFinite(loc.lat) && Number.isFinite(loc.lng))
-        ? `<button type="button" class="ml-1" title="${t.copyCoordinates_}" data-copy="${loc.lat.toFixed(6)}, ${loc.lng.toFixed(6)}">
+        ? `<button type="button" class="ml-1" title="${this.escapeHtml(t.copyCoordinates_)}" data-copy="${loc.lat.toFixed(6)}, ${loc.lng.toFixed(6)}">
             <i class="mdi mdi-content-copy" aria-hidden="true"></i>
           </button>`
         : '';
 
-      const eventType = loc.eventtype ? `<div class="d-flex align-center"><i class="mdi mdi-calendar-range mr-1"></i>${loc.eventtype || ''}</div>` : '';
+      const eventType = loc.eventtype ? `<div class="d-flex align-center"><i class="mdi mdi-calendar-range mr-1"></i>${this.escapeHtml(loc.eventtype)}</div>` : '';
 
-      const locNumber = loc.number ? `<div class="d-flex align-center">#${loc.number || ''}</div>` : '';
+      const locNumber = loc.number ? `<div class="d-flex align-center">#${this.escapeHtml(loc.number)}</div>` : '';
 
       const html = `<div class="popup-content d-flex flex-column ga-1">
         <div class="d-flex ga-2">${locNumber} ${parentId} ${eventType}</div>
-        <h4>${loc.title || ''}</h4>
+        <h4>${this.escapeHtml(loc.title)}</h4>
         <div class="d-flex align-center">
           <i class="mdi mdi-map-marker-outline mr-1"></i>
-          ${loc.full_string || ''}
+          ${this.escapeHtml(loc.full_string)}
           ${copyCoordsBtn}
         </div>
-        ${loc.main ? `<div>${t.mainIncident_}</div>` : ''}
+        ${loc.main ? `<div>${this.escapeHtml(t.mainIncident_)}</div>` : ''}
         ${dateRange}
       </div>`;
 

--- a/enferno/static/js/components/GlobalMap.js
+++ b/enferno/static/js/components/GlobalMap.js
@@ -70,54 +70,43 @@ const GlobalMap = Vue.defineComponent({
   },
 
   methods: {
-    escapeHtml(value) {
-      const entityMap = {
-        '&': '&amp;',
-        '<': '&lt;',
-        '>': '&gt;',
-        '"': '&quot;',
-        "'": '&#39;',
-      };
-
-      return String(value ?? '').replace(/[&<>"']/g, char => entityMap[char]);
-    },
     generatePopupContent(loc) {
       const t = this.translations;
 
       // Dates
       const dates = [];
-      if (loc.from_date) dates.push(`<span class="chip">${this.escapeHtml(this.$root.formatDate(loc.from_date, loc.from_date.includes('T00:00') ? this.$root.dateFormats.standardDate : this.$root.dateFormats.standardDatetime))}</span>`);
+      if (loc.from_date) dates.push(`<span class="chip">${escapeHtml(this.$root.formatDate(loc.from_date, loc.from_date.includes('T00:00') ? this.$root.dateFormats.standardDate : this.$root.dateFormats.standardDatetime))}</span>`);
       if (loc.from_date && loc.to_date) dates.push(`<i class="mdi mdi-arrow-right mr-1">`);
-      if (loc.to_date) dates.push(`<span></i>${this.escapeHtml(this.$root.formatDate(loc.to_date, loc.to_date.includes('T00:00') ? this.$root.dateFormats.standardDate : this.$root.dateFormats.standardDatetime))}</span>`);
+      if (loc.to_date) dates.push(`<span></i>${escapeHtml(this.$root.formatDate(loc.to_date, loc.to_date.includes('T00:00') ? this.$root.dateFormats.standardDate : this.$root.dateFormats.standardDatetime))}</span>`);
 
       const estimated = loc.estimated
-        ? `<i class="mdi mdi-calendar-question mr-1" title="${this.escapeHtml(t.timingForThisEventIsEstimated_)}"></i>`
+        ? `<i class="mdi mdi-calendar-question mr-1" title="${escapeHtml(t.timingForThisEventIsEstimated_)}"></i>`
         : '<i class="mdi mdi-calendar-clock mr-1"></i>';
 
       const dateRange = dates.length ? `<div class="d-flex">${estimated} ${dates.join(' ')}</div>` : '';
 
-      const parentId = loc?.parentId && loc?.show_parent_id ? `<div><i class="mdi mdi-link mr-1"></i>${this.escapeHtml(loc.parentId)}</div>` : '';
+      const parentId = loc?.parentId && loc?.show_parent_id ? `<div><i class="mdi mdi-link mr-1"></i>${escapeHtml(loc.parentId)}</div>` : '';
 
       // Copy button using data-copy instead of onclick
       const copyCoordsBtn = (Number.isFinite(loc.lat) && Number.isFinite(loc.lng))
-        ? `<button type="button" class="ml-1" title="${this.escapeHtml(t.copyCoordinates_)}" data-copy="${loc.lat.toFixed(6)}, ${loc.lng.toFixed(6)}">
+        ? `<button type="button" class="ml-1" title="${escapeHtml(t.copyCoordinates_)}" data-copy="${loc.lat.toFixed(6)}, ${loc.lng.toFixed(6)}">
             <i class="mdi mdi-content-copy" aria-hidden="true"></i>
           </button>`
         : '';
 
-      const eventType = loc.eventtype ? `<div class="d-flex align-center"><i class="mdi mdi-calendar-range mr-1"></i>${this.escapeHtml(loc.eventtype)}</div>` : '';
+      const eventType = loc.eventtype ? `<div class="d-flex align-center"><i class="mdi mdi-calendar-range mr-1"></i>${escapeHtml(loc.eventtype)}</div>` : '';
 
-      const locNumber = loc.number ? `<div class="d-flex align-center">#${this.escapeHtml(loc.number)}</div>` : '';
+      const locNumber = loc.number ? `<div class="d-flex align-center">#${escapeHtml(loc.number)}</div>` : '';
 
       const html = `<div class="popup-content d-flex flex-column ga-1">
         <div class="d-flex ga-2">${locNumber} ${parentId} ${eventType}</div>
-        <h4>${this.escapeHtml(loc.title)}</h4>
+        <h4>${escapeHtml(loc.title)}</h4>
         <div class="d-flex align-center">
           <i class="mdi mdi-map-marker-outline mr-1"></i>
-          ${this.escapeHtml(loc.full_string)}
+          ${escapeHtml(loc.full_string)}
           ${copyCoordsBtn}
         </div>
-        ${loc.main ? `<div>${this.escapeHtml(t.mainIncident_)}</div>` : ''}
+        ${loc.main ? `<div>${escapeHtml(t.mainIncident_)}</div>` : ''}
         ${dateRange}
       </div>`;
 

--- a/enferno/static/js/components/MissingPersonField.js
+++ b/enferno/static/js/components/MissingPersonField.js
@@ -6,7 +6,7 @@ const MissingPersonField = Vue.defineComponent({
   },
   data: function () {
     return {
-      translations: window.translations,
+      translations: translations,
     };
   },
   computed: {
@@ -15,7 +15,7 @@ const MissingPersonField = Vue.defineComponent({
         // type 1 = options + details
         if (!this.field) return '';
         const { opts = '', details = '-' } = this.field;
-        return `${opts}: ${details}`;
+        return `${escapeHtml(opts)}: ${escapeHtml(details)}`;
       }
 
       if (this.type === 2) {
@@ -25,7 +25,7 @@ const MissingPersonField = Vue.defineComponent({
       }
 
       // final case: simple field
-      return this.field;
+      return escapeHtml(this.field);
     },
     show() {
       if (this.type == 2) {
@@ -38,9 +38,9 @@ const MissingPersonField = Vue.defineComponent({
     formatReporter(rep) {
       const { name, contact, relationship } = rep;
       const output = [
-        name && `${this.translations.name_}: ${name}`,
-        contact && `${this.translations.contact_}: ${contact}`,
-        relationship && `${this.translations.relationship_}: ${relationship}`,
+        name && `${this.translations.name_}: ${escapeHtml(name)}`,
+        contact && `${this.translations.contact_}: ${escapeHtml(contact)}`,
+        relationship && `${this.translations.relationship_}: ${escapeHtml(relationship)}`,
       ]
         .filter(Boolean)
         .join('<br>');

--- a/enferno/static/js/components/MissingPersonField.js
+++ b/enferno/static/js/components/MissingPersonField.js
@@ -6,7 +6,7 @@ const MissingPersonField = Vue.defineComponent({
   },
   data: function () {
     return {
-      translations: translations,
+      translations: window.translations,
     };
   },
   computed: {

--- a/enferno/static/js/components/MissingPersonField.js
+++ b/enferno/static/js/components/MissingPersonField.js
@@ -14,18 +14,22 @@ const MissingPersonField = Vue.defineComponent({
       if (this.type === 1) {
         // type 1 = options + details
         if (!this.field) return '';
-        const { opts = '', details = '-' } = this.field;
-        return `${escapeHtml(opts)}: ${escapeHtml(details)}`;
+        const { opts = '', details = '' } = this.field;
+        const optsText = Array.isArray(opts) ? opts.join(', ') : opts;
+
+        if (!optsText) return details;
+        if (!details) return optsText;
+
+        return `${optsText}: ${details}`;
       }
 
       if (this.type === 2) {
         // type 2 = Reporters: list of objects
-        if (!Array.isArray(this.field) || !this.field.length) return '-';
-        return this.field.map(this.formatReporter).join('');
+        return '';
       }
 
       // final case: simple field
-      return escapeHtml(this.field);
+      return this.field;
     },
     show() {
       if (this.type == 2) {
@@ -33,25 +37,26 @@ const MissingPersonField = Vue.defineComponent({
       }
       return !!this.field;      
     },
-  },
-  methods: {
-    formatReporter(rep) {
-      const { name, contact, relationship } = rep;
-      const output = [
-        name && `${this.translations.name_}: ${escapeHtml(name)}`,
-        contact && `${this.translations.contact_}: ${escapeHtml(contact)}`,
-        relationship && `${this.translations.relationship_}: ${escapeHtml(relationship)}`,
-      ]
-        .filter(Boolean)
-        .join('<br>');
-
-      return output ? `<div class="elevation-1 my-3 pa-2 yellow lighten-5">${output}</div>` : '';
+    reporters() {
+      if (this.type !== 2 || !Array.isArray(this.field)) return [];
+      return this.field.filter(rep => rep && Object.keys(rep).length);
     },
   },
   template: `
     <v-sheet v-if="show" class="pa-1 pb-2 mb-2" color="transparent">
       <div class="caption grey--text text--darken-1">{{ title }}</div>
-      <span v-html="output"></span>
+      <template v-if="type === 2">
+        <div
+          v-for="(rep, index) in reporters"
+          :key="index"
+          class="elevation-1 my-3 pa-2 yellow lighten-5"
+        >
+          <div v-if="rep.name">{{ translations.name_ }}: {{ rep.name }}</div>
+          <div v-if="rep.contact">{{ translations.contact_ }}: {{ rep.contact }}</div>
+          <div v-if="rep.relationship">{{ translations.relationship_ }}: {{ rep.relationship }}</div>
+        </div>
+      </template>
+      <span v-else v-text="output"></span>
     </v-sheet>
   `,
 });

--- a/enferno/static/js/components/NotificationsList.js
+++ b/enferno/static/js/components/NotificationsList.js
@@ -128,13 +128,13 @@ const NotificationsList = Vue.defineComponent({
                                 :class="{ 'font-weight-bold': (!notification?.read_status || notification?.is_urgent) }"
                                 class="text-body-1"
                                 :style="getLineClampStyles(config.maxTitleLines)"
-                                v-html="notification?.title"
+                                v-text="notification?.title"
                             />
                             <v-list-item-subtitle class="mt-1" opacity="100">
                                 <div
                                 class="text-caption text-high-emphasis"
                                 :style="getLineClampStyles(config.maxSubtitleLines)"
-                                v-html="notification?.message"
+                                v-text="notification?.message"
                                 />
                                 <div class="d-flex justify-space-between align-center mt-2">
                                     <span class="text-caption text-high-emphasis">{{ getDateFromNotification(notification) }}</span>

--- a/enferno/static/js/components/Toast.js
+++ b/enferno/static/js/components/Toast.js
@@ -56,7 +56,7 @@ const Toast = Vue.defineComponent({
   template: `
     <v-snackbar v-model="open" multi-line v-bind="snackbarProps">
       <v-icon v-if="iconProps" class="mr-2" v-bind="iconProps"></v-icon>
-      <span v-html="message"></span>
+      <span style="white-space: pre-line;" v-text="message"></span>
       <template v-if="!hideActions" #actions>
           <v-btn icon="mdi-close" variant="text" @click="close"></v-btn>
       </template>

--- a/enferno/static/js/mixins/global-mixin.js
+++ b/enferno/static/js/mixins/global-mixin.js
@@ -115,15 +115,15 @@ const globalMixin = {
         },
         parseValidationError(response){
             if (response && response.errors){
-                let message = '';
+                const messages = [];
                 for(const field in response.errors){
                     let fieldName = field;
                     if (fieldName.startsWith('item.')){
                         fieldName = fieldName.substring(5);
                     }
-                    message += `<strong style="color:#b71c1c;">[${!fieldName.includes("__root__") ? fieldName : 'Validation Error'}]:</strong> ${response.errors[field]}<br/>`;
+                    messages.push(`[${!fieldName.includes("__root__") ? fieldName : 'Validation Error'}]: ${response.errors[field]}`);
                 }
-                return message;
+                return messages.join('\n');
             }
             return response;
         },

--- a/enferno/templates/layout.html
+++ b/enferno/templates/layout.html
@@ -64,7 +64,7 @@
             {% endblock %}
 
         <v-snackbar v-model="snackbar" multi-line>
-                <span v-html="snackMessage"></span>
+                <span style="white-space: pre-line;" v-text="snackMessage"></span>
             <template #actions>
                 <v-btn icon="mdi-close" variant="text" @click="snackbar = false"></v-btn>
             </template>

--- a/enferno/templates/security/wan_register.html
+++ b/enferno/templates/security/wan_register.html
@@ -191,7 +191,9 @@
                             if (result.error_msg) {
 
                                 const error_element = document.getElementById("wan-errors");
-                                error_element.innerHTML = `<em>${result.error_msg}</em>`;
+                                const error_message = document.createElement("em");
+                                error_message.textContent = result.error_msg;
+                                error_element.replaceChildren(error_message);
                             } else {
                                 document.getElementById("credential").value = result.credential;
                                 /* We auto-submit this form - there is a Submit button on the

--- a/enferno/templates/security/wan_verify.html
+++ b/enferno/templates/security/wan_verify.html
@@ -41,7 +41,9 @@
             document.forms["wan-signin-response-form"].submit();
           } else {
             const error_element = document.getElementById("wan-errors");
-            error_element.innerHTML = `<em>${result.error_msg}</em>`;
+            const error_message = document.createElement("em");
+            error_message.textContent = result.error_msg;
+            error_element.replaceChildren(error_message);
           }
         });
     </script>

--- a/enferno/templates/setup_wizard.html
+++ b/enferno/templates/setup_wizard.html
@@ -401,7 +401,7 @@
 
         <v-snackbar v-model="snackbar" multi-line>
 
-            <span v-html="snackMessage"></span>
+            <span style="white-space: pre-line;" v-text="snackMessage"></span>
 
             <template #actions>
                 <v-btn icon="mdi-close" variant="text" @click="snackbar = false"></v-btn>


### PR DESCRIPTION
## Description
This PR hardens several frontend render paths that were treating user/reference data as raw HTML.

Changes include:
- Escapes map popup fields before rendering.
- Renders notification titles/messages as text.
- Renders geolocation comments and missing-person fields safely.
- Renders WebAuthn errors as text.
- Renders snackbar/toast messages as text by default.

This prevents payloads like `<img src=x onerror=alert(1)>` from executing in the UI while preserving normal display text like R&D and A < B.

## How to Test
- Save a title/comment/field value containing: `<img src=x onerror=alert(1)>`
- View it in the map popup, notifications, geolocation comments, missing-person card, and snackbar flows.
- Confirm it displays as plain text and no alert runs.
- Also test normal values like R&D, A < B, and quotes display correctly.

## Jira ID (if applicable)
[e.g., BYNT-123]
