### PR TITLE
Support deleting redactions

### DIFF
--- a/enferno/admin/templates/admin/bulletins.html
+++ b/enferno/admin/templates/admin/bulletins.html
@@ -926,7 +926,15 @@
                     onMediaRedacted() {
                         this.showSnack("{{ _('Redaction saved') }}");
                         const id = this.$route.params.id || this.bulletin?.id;
-                        if (id) this.showBulletin(id);
+                        if (id) {
+                            // Media redacted on bulletin drawer, refresh the bulletin to get the updated media list
+                            this.showBulletin(id);
+                        } else if (this.editedItem?.id) {
+                            // Media redacted on bulletin editor dialog, refresh the bulletin to get the updated media list
+                            api.get(`/admin/api/bulletin/${this.editedItem.id}`).then(response => {
+                                this.editedItem.medias = response.data?.medias;
+                            }).catch(err => this.showSnack(handleRequestError(err)));
+                        }
                     },
                     handleRoute({ initialLoad = false } = {}) {
                         if (this.$route.params.id) this.showBulletin(this.$route.params.id);

--- a/enferno/admin/templates/admin/jsapi.jinja2
+++ b/enferno/admin/templates/admin/jsapi.jinja2
@@ -627,6 +627,8 @@ etag_ : "{{ _('File Hash') }}",
 filename_ : "{{ _('Filename') }}",
 previewNotAvailable_ : "{{ _('Preview not available') }}",
 downloadFile_ : "{{ _('Download file') }}",
+onlyRedactionsCanBeDeleted_: "{{ _('Only redactions can be deleted') }}",
+redact_: "{{ _('Redact') }}",
 
 // System Administration
 defaultsLoaded_: "{{ _('Default settings loaded. Click Save to apply changes.') }}",

--- a/enferno/admin/templates/admin/partials/media_dialog.html
+++ b/enferno/admin/templates/admin/partials/media_dialog.html
@@ -39,6 +39,7 @@
           :medias="editedItem.medias"
           @media-click="handleExpandedMedia({ rendererId: 'media-dialog', ...$event }); this.$refs.bulletinDialogSplitViewRef?.resetToCenter()"
           @remove-media="removeMedia"
+          @remove-redaction="removeRedaction($event)"
         ></media-grid>
       </v-card-text>
     </v-card>

--- a/enferno/static/js/components/BulletinCard.js
+++ b/enferno/static/js/components/BulletinCard.js
@@ -269,7 +269,7 @@ const BulletinCard = Vue.defineComponent({
         
         <v-card-text>
           
-          <media-grid prioritize-videos :medias="bulletin.medias" @media-click="$root.handleExpandedMedia({ rendererId: mediaRendererId, ...$event })"></media-grid>
+          <media-grid prioritize-videos :medias="bulletin.medias" @media-click="$root.handleExpandedMedia({ rendererId: mediaRendererId, ...$event })" @remove-redaction="$root.removeRedaction($event)"></media-grid>
         </v-card-text>
       </v-card>
 

--- a/enferno/static/js/components/MediaCard.js
+++ b/enferno/static/js/components/MediaCard.js
@@ -131,7 +131,7 @@ const MediaCard = Vue.defineComponent({
       default: () => [],
     },
   },
-  emits: ['media-click'],
+  emits: ['media-click', 'remove-redaction'],
   data() {
     return {
       s3url: '',
@@ -189,7 +189,7 @@ const MediaCard = Vue.defineComponent({
       const isRedactable = this.mediaType === 'pdf' || this.mediaType === 'image';
       const visible = (this.isCurrentUserAdmin || this.isCurrentUserDA) && isRedactable;
       return {
-        text: this.translations.redact_ || 'Redact',
+        text: this.translations.redact_,
         visible,
         disabled: !this.media?.id,
       };
@@ -229,6 +229,15 @@ const MediaCard = Vue.defineComponent({
         })
         .catch(() => this.$root.showSnack('Failed to load OCR text'))
         .finally(() => this.ocrLoading = false);
+    },
+    confirmRemoveRedaction(redaction) {
+      this.$root.$confirm({
+        acceptProps: { color: 'error' },
+        dialogProps: { width: 780 },
+        onAccept: () => {
+          this.$emit('remove-redaction', redaction);
+        },
+      });
     },
     copyToClipboard(text) {
       navigator.clipboard.writeText(text)
@@ -298,8 +307,8 @@ const MediaCard = Vue.defineComponent({
           <v-expansion-panel @group:selected="loadOcrText">
             <v-expansion-panel-title class="py-1 text-caption" style="min-height: 36px;">
               <v-icon icon="mdi-text-recognition" size="small" class="mr-2"></v-icon>
-              {{ translations.extractedText_ || 'Extracted Text' }}
-              <v-chip size="x-small" class="ml-2" variant="text">{{ media.extraction?.word_count }} {{ translations.words_ || 'words' }}</v-chip>
+              {{ translations.extractedText_ }}
+              <v-chip size="x-small" class="ml-2" variant="text">{{ media.extraction?.word_count }} {{ translations.words_ }}</v-chip>
             </v-expansion-panel-title>
             <v-expansion-panel-text>
               <v-progress-linear v-if="ocrLoading" indeterminate color="primary" class="mb-2"></v-progress-linear>
@@ -316,46 +325,59 @@ const MediaCard = Vue.defineComponent({
       <template v-if="redactions.length">
         <v-divider></v-divider>
         <div
-          class="d-flex align-center justify-space-between px-3 py-2 cursor-pointer"
+          class="d-flex align-center justify-space-between px-3 py-2 cursor-pointer ga-2"
           style="min-height: 36px;"
           @click="showRedactions = !showRedactions"
         >
           <div class="d-flex align-center ga-2">
-            <v-icon icon="mdi-marker" size="14" color="warning"></v-icon>
+            <v-icon icon="mdi-marker" size="18" color="warning"></v-icon>
             <span class="text-caption font-weight-medium">{{ redactions.length }} redacted cop{{ redactions.length > 1 ? 'ies' : 'y' }}</span>
           </div>
-          <v-icon :icon="showRedactions ? 'mdi-chevron-up' : 'mdi-chevron-down'" size="16" class="opacity-60"></v-icon>
+          <v-icon :icon="showRedactions ? 'mdi-chevron-up' : 'mdi-chevron-down'" size="18" class="opacity-60"></v-icon>
         </div>
         <v-expand-transition>
           <div v-if="showRedactions">
             <v-divider></v-divider>
-            <div class="pa-2 bg-grey-lighten-4 d-flex flex-row flex-wrap ga-2">
-              <v-hover v-slot="{ isHovering, props: hoverProps }" v-for="copy in redactions" :key="copy.id">
-              <div
+            <v-row no-gutters class="pa-2 bg-grey-lighten-4">
+              <v-col cols="6" v-for="redaction in redactions" :key="redaction.id" class="pa-1">
+              <v-hover v-slot="{ isHovering, props: hoverProps }">
+              <v-card
                 v-bind="hoverProps"
-                class="d-flex flex-column rounded bg-white overflow-hidden"
-                style="width: 96px; border: 1px solid rgba(0,0,0,0.08);"
+                rounded
+                elevation="1"
+                class="overflow-hidden"
               >
-                <div class="position-relative" style="height: 64px;" @click.stop="$emit('media-click', { media: copy, mediaType: $root.getFileTypeFromMimeType(copy.fileType) })">
-                  <media-thumbnail :media="copy" :show-hover-icon="isHovering" :compact="true" clickable></media-thumbnail>
+                <div class="position-relative" style="height: 80px;" @click.stop="$emit('media-click', { media: redaction, mediaType: $root.getFileTypeFromMimeType(redaction.fileType) })">
+                  <media-thumbnail :media="redaction" :show-hover-icon="isHovering" :compact="true" clickable></media-thumbnail>
                 </div>
-                <div class="d-flex align-center px-1" style="min-height: 24px;">
-                  <v-tooltip location="top" :text="copy.title || copy.filename">
+                <div class="d-flex align-center px-1 ga-1" style="min-height: 28px;">
+                  <v-tooltip location="top" :text="redaction.title || redaction.filename">
                     <template #activator="{ props: ttProps }">
-                      <span v-bind="ttProps" class="text-truncate flex-grow-1" style="font-size: 10px; min-width: 0; opacity: 0.7;">{{ copy.title || copy.filename }}</span>
+                      <span v-bind="ttProps" class="text-truncate flex-grow-1 text-caption opacity-70">{{ redaction.title || redaction.filename }}</span>
                     </template>
                   </v-tooltip>
-                  <v-btn
-                    v-if="typeof $root?.openRedactor === 'function'"
-                    icon="mdi-marker"
-                    variant="text"
-                    density="compact"
-                    @click.stop="$root.openRedactor(copy)"
-                  ></v-btn>
+                  <v-fade-transition>
+                    <div v-if="isHovering" class="d-flex ga-1">
+                      <v-icon
+                        icon="mdi-marker"
+                        size="18"
+                        class="cursor-pointer"
+                        @click.stop="$root.openRedactor(redaction)"
+                      ></v-icon>
+                      <v-icon
+                        icon="mdi-delete-outline"
+                        size="18"
+                        color="error"
+                        class="cursor-pointer"
+                        @click.stop="confirmRemoveRedaction(redaction)"
+                      ></v-icon>
+                    </div>
+                  </v-fade-transition>
                 </div>
-              </div>
+              </v-card>
               </v-hover>
-            </div>
+              </v-col>
+            </v-row>
           </div>
         </v-expand-transition>
       </template>

--- a/enferno/static/js/components/MediaCard.js
+++ b/enferno/static/js/components/MediaCard.js
@@ -357,8 +357,9 @@ const MediaCard = Vue.defineComponent({
                     </template>
                   </v-tooltip>
                   <v-fade-transition>
-                    <div v-if="isHovering" class="d-flex ga-1">
+                    <div v-if="isHovering && (isCurrentUserAdmin || isCurrentUserDA)" class="d-flex ga-1">
                       <v-icon
+                        v-if="typeof $root?.openRedactor === 'function'"
                         icon="mdi-marker"
                         size="18"
                         class="cursor-pointer"

--- a/enferno/static/js/components/MediaGrid.js
+++ b/enferno/static/js/components/MediaGrid.js
@@ -6,7 +6,7 @@ const MediaGrid = Vue.defineComponent({
     prioritizeVideos: Boolean,
     miniMode: Boolean,
   },
-  emits: ['remove-media', 'media-click'],
+  emits: ['remove-media', 'remove-redaction', 'media-click'],
   computed: {
     primaryMedia() {
       const list = this.prioritizeVideos ? this.sortMediaByFileType(this.medias) : (this.medias || []);
@@ -46,6 +46,7 @@ const MediaGrid = Vue.defineComponent({
         <media-card
           v-for="media in primaryMedia" :key="media.id || media.uuid"
           @media-click="$emit('media-click', $event)"
+          @remove-redaction="$emit('remove-redaction', $event)"
           :media="media"
           :mini-mode="miniMode"
           :redactions="redactionsBySource[media.id] || []"

--- a/enferno/static/js/mixins/media-mixin.js
+++ b/enferno/static/js/mixins/media-mixin.js
@@ -320,7 +320,10 @@ const mediaMixin = {
       }
     },
     removeRedaction(redaction) {
-      if (!redaction.isRedaction) return;
+      if (!redaction.isRedaction) {
+        this.showSnack(window.translations.onlyRedactionsCanBeDeleted_);
+        return;
+      }
       const index = this.editedItem.medias.findIndex(m => m.id === redaction.id);
       if (index !== -1) this.editedItem.medias.splice(index, 1);
       axios.delete(`/admin/api/media/redaction/${redaction.id}`)

--- a/enferno/static/js/mixins/media-mixin.js
+++ b/enferno/static/js/mixins/media-mixin.js
@@ -326,7 +326,7 @@ const mediaMixin = {
       }
       const index = this.editedItem.medias.findIndex(m => m.id === redaction.id);
       if (index !== -1) this.editedItem.medias.splice(index, 1);
-      axios.delete(`/admin/api/media/redaction/${redaction.id}`)
+      api.delete(`/admin/api/media/redaction/${redaction.id}`)
         .catch(err => {
           this.editedItem.medias.splice(index, 0, redaction);
           this.showSnack(handleRequestError(err));

--- a/enferno/static/js/mixins/media-mixin.js
+++ b/enferno/static/js/mixins/media-mixin.js
@@ -319,6 +319,16 @@ const mediaMixin = {
         this.editedItem.medias.splice(index, 1);
       }
     },
+    removeRedaction(redaction) {
+      if (!redaction.isRedaction) return;
+      const index = this.editedItem.medias.findIndex(m => m.id === redaction.id);
+      if (index !== -1) this.editedItem.medias.splice(index, 1);
+      axios.delete(`/admin/api/media/redaction/${redaction.id}`)
+        .catch(err => {
+          this.editedItem.medias.splice(index, 0, redaction);
+          this.showSnack(handleRequestError(err));
+        });
+    },
 
     closeMediaDialog() {
       this.destroyCrop();


### PR DESCRIPTION
## Description
Adds delete button for redacted copies (confirm dialog, optimistic removal, rollback on error). Fixes media list not refreshing after saving a new redaction in both the drawer and edit dialog. Redact/delete icons are gated to Admin/DA only.
