### PR TITLE
fix(redaction): honor EXIF orientation when burning image redactions

### DIFF
--- a/enferno/admin/templates/admin/partials/media_dialog.html
+++ b/enferno/admin/templates/admin/partials/media_dialog.html
@@ -22,6 +22,7 @@
           renderer-id="media-dialog"
           :media="expandedByRenderer?.['media-dialog']?.media"
           :media-type="expandedByRenderer?.['media-dialog']?.mediaType"
+          :initial-orientation="expandedByRenderer?.['media-dialog']?.media?.orientation || 0"
           :use-metadata="true"
           class="mb-4"
           content-style="height: calc(100vh - 450px);"

--- a/enferno/static/js/components/ActorCard.js
+++ b/enferno/static/js/components/ActorCard.js
@@ -427,6 +427,7 @@ const ActorCard = Vue.defineComponent({
                 :renderer-id="mediaRendererId"
                 :media="$root.expandedByRenderer?.[mediaRendererId]?.media"
                 :media-type="$root.expandedByRenderer?.[mediaRendererId]?.mediaType"
+                :initial-orientation="$root.expandedByRenderer?.[mediaRendererId]?.media?.orientation || 0"
                 @ready="$root.onMediaRendererReady"
                 @fullscreen="$root.handleFullscreen(mediaRendererId)"
                 @close="$root.closeExpandedMedia(mediaRendererId)"

--- a/enferno/static/js/components/ImageViewer.js
+++ b/enferno/static/js/components/ImageViewer.js
@@ -69,17 +69,18 @@ const ImageViewer = Vue.defineComponent({
         
         applyInitialRotation(lgInstance) {
             if (this.initialOrientation === 0) return;
-            
+
             const handler = (e) => {
                 const rotatePlugin = this.getRotatePlugin(lgInstance);
                 const index = e.detail.index;
-                
+
                 if (rotatePlugin?.rotateValuesList?.[index]) {
                     rotatePlugin.rotateValuesList[index].rotate = this.initialOrientation;
                     rotatePlugin.applyStyles();
+                    lgInstance.el.dispatchEvent(new CustomEvent('lgRotateRight', { detail: { rotate: this.initialOrientation } }));
                 }
             };
-            
+
             lgInstance.el.addEventListener('lgSlideItemLoad', handler, { once: true });
         },
         

--- a/enferno/utils/redaction_utils.py
+++ b/enferno/utils/redaction_utils.py
@@ -1,7 +1,7 @@
 import io
 
 import fitz
-from PIL import Image, ImageDraw
+from PIL import Image, ImageDraw, ImageOps
 
 
 class RedactionError(ValueError):
@@ -82,7 +82,11 @@ def redact_image_bytes(src: bytes, rects: list[dict]) -> bytes:
     if not rects:
         raise RedactionError("No redaction regions provided")
 
-    img = Image.open(io.BytesIO(src)).convert("RGB")
+    # Bake in EXIF orientation so we draw on the same pixels the browser displayed
+    # (browsers honor EXIF; PIL does not). Otherwise boxes land in the wrong place and
+    # the saved copy comes back at 0deg. The DB orientation axis is handled separately
+    # by rotate_rect_to_original in the caller.
+    img = ImageOps.exif_transpose(Image.open(io.BytesIO(src))).convert("RGB")
     draw = ImageDraw.Draw(img)
     width, height = img.size
     for rect in rects:

--- a/tests/admin/test_redaction.py
+++ b/tests/admin/test_redaction.py
@@ -64,6 +64,24 @@ def test_redact_image_bytes_burns_black_box():
     assert result.getpixel((90, 90)) == (255, 255, 255)
 
 
+def test_redact_image_bytes_honors_exif_orientation():
+    # Raw pixels are landscape (200x100) but EXIF says rotate 90 CW, so the browser
+    # (and the redaction UI) show it portrait (100x200). Boxes are drawn in that
+    # displayed space, so the backend must transpose before burning.
+    img = Image.new("RGB", (200, 100), "white")
+    exif = img.getexif()
+    exif[274] = 6  # Orientation: rotate 90 CW on display
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", exif=exif)
+
+    out = redact_image_bytes(buf.getvalue(), [{"x": 0.0, "y": 0.0, "w": 0.5, "h": 0.5}])
+
+    result = Image.open(io.BytesIO(out)).convert("RGB")
+    assert result.size == (100, 200)  # displayed (transposed) dimensions, not raw
+    assert result.getpixel((10, 10)) == (0, 0, 0)
+    assert result.getpixel((90, 190)) == (255, 255, 255)
+
+
 def test_redaction_rejects_out_of_bounds_coordinates():
     src = _one_page_pdf_with_text()
     pages = [{"page": 0, "rects": [{"x": -0.1, "y": 0, "w": 0.2, "h": 0.2}]}]


### PR DESCRIPTION
## Problem

Redacting an image whose orientation comes from an **EXIF tag** (rather than physically rotated pixels) produced two symptoms: the black boxes landed in the wrong place, and the saved redacted copy came back at 0°, not the orientation the user was looking at in the redaction dialog.

Reported from a DA; reproduced by editing only the EXIF orientation tag of a sample (physically-rotated samples worked fine).

## Root cause

`redact_image_bytes` opened the image with `Image.open(...).convert("RGB")`, which **ignores EXIF orientation**. Browsers do the opposite: they honor EXIF, so the redaction UI displayed the image rotated and captured the boxes in that oriented space. The backend then drew on the raw, un-rotated pixels and saved a JPEG with EXIF stripped, so both the box positions and the output orientation diverged from what the user saw.

The DB `orientation` axis (manual/OCR rotation) was already handled via `rotate_rect_to_original`; EXIF was the missing axis.

## Fix

Normalize with `ImageOps.exif_transpose` before drawing, so the backend operates on the same pixels the browser displayed. This is the existing house pattern: the OCR ingest path (`enferno/utils/ocr/image.py`) already does the exact same thing. Redaction was simply the one image path that skipped it.

## Test

Added a test that builds a landscape image tagged EXIF orientation 6 (displayed portrait), redacts the displayed top-left quadrant, and asserts the output is the transposed dimensions with the box in the right place. Fails without the fix, passes with it. Full redaction suite green.