### PR TITLE
fix(deps): pin flask-security-too below 5.8 (GHSA-f66q-9rf6-8795)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,9 @@ dependencies = [
     "Flask-Principal>=0.4.0",
     "flask-redis>=0.4.0",
     "Flask-Script>=2.0.6",
-    "flask-security-too>=5.7.0",
+    # Cap below 5.8: GHSA-f66q-9rf6-8795 (WebAuthn reauth freshness bypass) affects 5.8.0-5.8.1.
+    # Lift the cap once a patched 5.8.x/5.9 release ships and templates are re-verified.
+    "flask-security-too>=5.7.0,<5.8.0",
     "Flask-Session>=0.8.0",
     "flask-shell-ipython>=0.5.3",
     "Flask-SQLAlchemy>=3.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -337,7 +337,7 @@ requires-dist = [
     { name = "flask-pydantic", marker = "extra == 'dev'", specifier = ">=0.13.0" },
     { name = "flask-redis", specifier = ">=0.4.0" },
     { name = "flask-script", specifier = ">=2.0.6" },
-    { name = "flask-security-too", specifier = ">=5.7.0" },
+    { name = "flask-security-too", specifier = ">=5.7.0,<5.8.0" },
     { name = "flask-session", specifier = ">=0.8.0" },
     { name = "flask-shell-ipython", specifier = ">=0.5.3" },
     { name = "flask-sqlalchemy", specifier = ">=3.1.0" },


### PR DESCRIPTION
## What

Cap `flask-security-too` to `>=5.7.0,<5.8.0`.

## Why

`pip-audit` (CI) flags **GHSA-f66q-9rf6-8795**, a WebAuthn reauthentication freshness bypass affecting flask-security-too **5.8.0–5.8.1**. The advisory has **no patched release** yet (5.8.1 is the current latest on PyPI), so there is nothing to upgrade *to*.

The project was already resolving/locking to **5.7.1**, which is **not** affected. CI failed only because `pip-audit .` re-resolves the open-ended `>=5.7.0` constraint to the newest matching release (5.8.1) rather than the shipped 5.7.1. Capping below 5.8 keeps both the resolver and the auditor on 5.7.1.

## Scope / risk

- **No version change** — resolved version stays 5.7.1 (uv.lock diff is a single specifier line).
- **No template work** — Bayanat overrides several flask-security templates with custom Vue-based ones; since the version is unchanged, none are affected.
- Only `pyproject.toml` (+ a comment noting the trigger to lift the cap) and `uv.lock` change.

## Verified

- `uv run pip-audit .` → **No known vulnerabilities found** (exit 0).
- Full test suite: **782 passed, 4 skipped** (identical to baseline).

Lift the cap once a patched 5.8.x/5.9 ships and the overridden security templates are re-verified against it.