### PR TITLE
Export all media files per item instead of only the first

### DIFF
--- a/enferno/tasks/exports.py
+++ b/enferno/tasks/exports.py
@@ -264,6 +264,14 @@ def generate_export_media(previous_result: int) -> t.id | Literal[False]:
         # UI switch disabled, but just in case...
         return False
 
+    if not cfg.FILESYSTEM_LOCAL:
+        s3 = boto3.client(
+            "s3",
+            aws_access_key_id=cfg.AWS_ACCESS_KEY_ID,
+            aws_secret_access_key=cfg.AWS_SECRET_ACCESS_KEY,
+            region_name=cfg.AWS_REGION,
+        )
+
     for item in items:
         for media in item.medias:
             target_file = f"{Export.export_dir}/{export_request.file_id}/{media.media_file}"
@@ -280,12 +288,6 @@ def generate_export_media(previous_result: int) -> t.id | Literal[False]:
                     clear_failed_export(export_request)
                     return False  # to stop chain
             else:
-                s3 = boto3.client(
-                    "s3",
-                    aws_access_key_id=cfg.AWS_ACCESS_KEY_ID,
-                    aws_secret_access_key=cfg.AWS_SECRET_ACCESS_KEY,
-                    region_name=cfg.AWS_REGION,
-                )
                 try:
                     s3.download_file(cfg.S3_BUCKET, media.media_file, target_file)
                 except Exception:

--- a/enferno/tasks/exports.py
+++ b/enferno/tasks/exports.py
@@ -265,8 +265,7 @@ def generate_export_media(previous_result: int) -> t.id | Literal[False]:
         return False
 
     for item in items:
-        if item.medias:
-            media = item.medias[0]
+        for media in item.medias:
             target_file = f"{Export.export_dir}/{export_request.file_id}/{media.media_file}"
 
             if cfg.FILESYSTEM_LOCAL:
@@ -297,7 +296,7 @@ def generate_export_media(previous_result: int) -> t.id | Literal[False]:
                     clear_failed_export(export_request)
                     return False  # to stop chain
 
-        time.sleep(0.05)
+            time.sleep(0.05)
     return export_request.id
 
 


### PR DESCRIPTION
Fixes BYNT-1727.

`generate_export_media` copied only `item.medias[0]`, so bulletins (and actors) with multiple media attachments exported incomplete data. Now all media files linked to each exported item are included, for both local filesystem and S3 storage. The per-file throttle sleep moved inside the media loop so S3 download pacing stays consistent.

Media filenames are UUID-based so there are no collision concerns in the export folder.