### PR TITLE
Show secondary-language actor name in list when primary is empty

### DIFF
--- a/enferno/admin/models/Actor.py
+++ b/enferno/admin/models/Actor.py
@@ -294,11 +294,7 @@ class Actor(db.Model, BaseMixin):
 
     @staticmethod
     def gen_full_name(first_name: str, last_name: str, middle_name: Optional[str] = None) -> str:
-        name = first_name
-        if middle_name:
-            name = name + " " + middle_name
-        name = name + " " + last_name
-        return name
+        return " ".join(part for part in (first_name, middle_name, last_name) if part)
 
     # populate actor object from json dict
     def from_json(self, json: dict[str, Any]) -> "Actor":

--- a/enferno/admin/templates/admin/actors.html
+++ b/enferno/admin/templates/admin/actors.html
@@ -214,6 +214,10 @@
                         
                         <template v-if="fetchingRecordsError" v-slot:no-data></template>
 
+                        <template v-slot:item.name="{item}">
+                            ${ (item.name || '').trim() || item.name_ar }
+                        </template>
+
                         <template v-slot:item.type="{item}">
                             <v-tooltip :text="item.type">
                                 <template v-slot:activator="{props}">


### PR DESCRIPTION
Fixes BYNT-1719.

Two parts:

1. `gen_full_name` joined name parts unconditionally, so a Person created with only Arabic names got `name = " "` (a truthy single space). That junk value defeated the `name or None` guard in serialization and also pollutes the search vector. It now joins only non-empty parts.
2. The actors list rendered `item.name` directly, showing blank for such actors. The name column now falls back to `name_ar` when the primary name is empty (trimmed, so existing rows with the legacy `" "` value display correctly without a data migration).

The preview card, relate dialogs, and search results already render both languages, so the list column was the only blank surface. Kept the fallback display-side to avoid feeding `name_ar` into the editable `name` field of the edit dialog for entities.