### PR TITLE
Search translated titles in lookup typeahead endpoints

### DIFF
--- a/enferno/admin/views/eventtypes.py
+++ b/enferno/admin/views/eventtypes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from flask import Response, request
 from flask.templating import render_template
 from flask_security.decorators import current_user, roles_accepted, roles_required
+from sqlalchemy import or_
 
 from enferno.extensions import db
 from enferno.admin.constants import Constants
@@ -42,7 +43,7 @@ def api_eventtypes() -> Response:
     per_page = request.args.get("per_page", PER_PAGE, int)
 
     if q is not None:
-        query.append(Eventtype.title.ilike("%" + q + "%"))
+        query.append(or_(Eventtype.title.ilike(f"%{q}%"), Eventtype.title_ar.ilike(f"%{q}%")))
 
     typ = request.args.get("typ", None)
     if typ and typ in ["for_bulletin", "for_actor", "for_incident"]:

--- a/enferno/admin/views/labels.py
+++ b/enferno/admin/views/labels.py
@@ -43,7 +43,12 @@ def api_labels() -> Response:
 
     if q:
         words = q.split(" ")
-        query.extend([Label.title.ilike(f"%{word}%") for word in words])
+        query.extend(
+            [
+                or_(Label.title.ilike(f"%{word}%"), Label.title_ar.ilike(f"%{word}%"))
+                for word in words
+            ]
+        )
 
     typ = request.args.get("typ", None)
     if typ and typ in ["for_bulletin", "for_actor", "for_incident", "for_offline"]:

--- a/enferno/admin/views/sources.py
+++ b/enferno/admin/views/sources.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from flask import Response, request
 from flask.templating import render_template
 from flask_security.decorators import current_user, roles_accepted, roles_required
-from sqlalchemy import desc
+from sqlalchemy import desc, or_
 
 from enferno.extensions import db
 from enferno.admin.constants import Constants
@@ -47,7 +47,9 @@ def api_sources() -> Response:
     if q:
         words = q.split(" ")
         for word in words:
-            query = query.filter(Source.title.ilike(f"%{word}%"))
+            query = query.filter(
+                or_(Source.title.ilike(f"%{word}%"), Source.title_ar.ilike(f"%{word}%"))
+            )
 
         sources = query.all()
         children = Source.get_children(sources)

--- a/enferno/admin/views/violations.py
+++ b/enferno/admin/views/violations.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from flask import Response, request
 from flask_security.decorators import current_user, roles_accepted, roles_required
+from sqlalchemy import or_
 
 from enferno.extensions import db
 from enferno.admin.constants import Constants
@@ -33,7 +34,12 @@ def api_potentialviolations(page: int) -> Response:
     q = request.args.get("q", None)
     per_page = request.args.get("per_page", PER_PAGE, int)
     if q is not None:
-        query.append(PotentialViolation.title.ilike("%" + q + "%"))
+        query.append(
+            or_(
+                PotentialViolation.title.ilike(f"%{q}%"),
+                PotentialViolation.title_ar.ilike(f"%{q}%"),
+            )
+        )
     result = (
         PotentialViolation.query.filter(*query)
         .order_by(PotentialViolation.id)
@@ -179,7 +185,12 @@ def api_claimedviolations(page: int) -> Response:
     q = request.args.get("q", None)
     per_page = request.args.get("per_page", PER_PAGE, int)
     if q is not None:
-        query.append(ClaimedViolation.title.ilike("%" + q + "%"))
+        query.append(
+            or_(
+                ClaimedViolation.title.ilike(f"%{q}%"),
+                ClaimedViolation.title_ar.ilike(f"%{q}%"),
+            )
+        )
     result = (
         ClaimedViolation.query.filter(*query)
         .order_by(ClaimedViolation.id)

--- a/tests/test_lookup_crud.py
+++ b/tests/test_lookup_crud.py
@@ -477,3 +477,42 @@ class TestDeleteIDNumberTypeStillReferenced:
         assert resp.status_code == expected
         if expected == 409:
             assert "is referenced by" in resp.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# Translated-title search (typeahead endpoints)
+# ---------------------------------------------------------------------------
+
+_TRANSLATED_SEARCH_PARAMS = [
+    ("labels", "/admin/api/labels/", {"title": "Arrest", "title_ar": "اعتقال"}),
+    ("sources", "/admin/api/sources/", {"title": "Witness", "title_ar": "شاهد"}),
+    ("event_types", "/admin/api/eventtypes/", {"title": "Bombing", "title_ar": "قصف"}),
+    (
+        "potential_violations",
+        "/admin/api/potentialviolation/",
+        {"title": "Torture", "title_ar": "تعذيب"},
+    ),
+    (
+        "claimed_violations",
+        "/admin/api/claimedviolation/",
+        {"title": "Detention", "title_ar": "احتجاز"},
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "entity,list_url,fields",
+    _TRANSLATED_SEARCH_PARAMS,
+    ids=[p[0] for p in _TRANSLATED_SEARCH_PARAMS],
+)
+def test_lookup_search_by_translated_title(request, session, entity, list_url, fields):
+    Model = _get_model_map()[entity]
+    item = Model(**fields)
+    session.add(item)
+    session.commit()
+
+    client = request.getfixturevalue("admin_client")
+    resp = client.get(f"{list_url}?q={fields['title_ar']}", headers=HEADERS)
+    assert resp.status_code == 200
+    ids = [i["id"] for i in resp.json["data"]["items"]]
+    assert item.id in ids


### PR DESCRIPTION
## Summary
Typeahead search on several lookup endpoints only matched the primary `title`, so typing a translated (Arabic) term returned no suggestions even when `title_ar` was populated. This brings them in line with the reference-data endpoints (countries, ethnographies, dialects, ID number types), which already match `or_(title, title_tr)`.

Endpoints fixed:
- `/admin/api/labels/`
- `/admin/api/sources/`
- `/admin/api/eventtypes/`
- `/admin/api/potentialviolation/`
- `/admin/api/claimedviolation/`

No schema changes. Entity search (search_utils) is unaffected since it filters by id.

Addresses the searchability half of BYNT-1761; displaying translated values in pickers is a separate follow-up.

## Test
Added `test_lookup_search_by_translated_title` covering all five endpoints (fails without the fix, passes with it). Full `tests/test_lookup_crud.py` module passes (217 passed).