### PR TITLE
Improve multilingual name display fallbacks

### DIFF
--- a/enferno/admin/templates/admin/actors.html
+++ b/enferno/admin/templates/admin/actors.html
@@ -215,7 +215,7 @@
                         <template v-if="fetchingRecordsError" v-slot:no-data></template>
 
                         <template v-slot:item.name="{item}">
-                            ${ (item.name || '').trim() || item.name_ar }
+                            <uni-field disable-spacing :english="(item.name || '').trim()" :arabic="item.name_ar.trim()"></uni-field>
                         </template>
 
                         <template v-slot:item.type="{item}">

--- a/enferno/admin/templates/admin/actors.html
+++ b/enferno/admin/templates/admin/actors.html
@@ -215,7 +215,7 @@
                         <template v-if="fetchingRecordsError" v-slot:no-data></template>
 
                         <template v-slot:item.name="{item}">
-                            <uni-field disable-spacing :english="(item.name || '').trim()" :arabic="item.name_ar.trim()"></uni-field>
+                            <uni-field disable-spacing :english="item.name" :arabic="item.name_ar"></uni-field>
                         </template>
 
                         <template v-slot:item.type="{item}">

--- a/enferno/static/js/common/config.js
+++ b/enferno/static/js/common/config.js
@@ -835,3 +835,14 @@ function loadScript(src) {
   loadedScripts.set(src, promise);
   return promise;
 }
+
+const textUtils = {
+  normalizeDisplayText(value) {
+    if (value === null || value === undefined) return '';
+    return typeof value === 'string' ? value.trim() : value;
+  },
+
+  hasText(value) {
+    return this.normalizeDisplayText(value) !== '';
+  },
+};

--- a/enferno/static/js/components/DualField.js
+++ b/enferno/static/js/components/DualField.js
@@ -49,23 +49,34 @@ const DualField = Vue.defineComponent({
   emits: ['update:original', 'update:translation'],
   data() {
     return {
-      isOriginalVisible: true,
+      isOriginalVisible: !(!this.original && this.translation),
       localOriginal: this.original,
       localTranslation: this.translation,
+      hasAutoSelected: !!(this.original || this.translation),
     };
   },
   watch: {
     // Watch for prop changes and update local copies accordingly
     original(newVal) {
       this.localOriginal = newVal;
+      this.autoSelectVisibleField();
     },
     translation(newVal) {
       this.localTranslation = newVal;
+      this.autoSelectVisibleField();
     },
   },
   methods: {
     toggleField() {
       this.isOriginalVisible = !this.isOriginalVisible;
+    },
+    autoSelectVisibleField() {
+      // Only runs once, the first time data arrives (e.g. async fetch after mount).
+      // Skipped afterwards so it never overrides the user's manual toggle while editing.
+      if (this.hasAutoSelected) return;
+      if (!this.original && !this.translation) return;
+      this.hasAutoSelected = true;
+      this.isOriginalVisible = !(!this.original && this.translation);
     },
     setUnknown() {
       if (this.allowUnknown) {

--- a/enferno/static/js/components/DualField.js
+++ b/enferno/static/js/components/DualField.js
@@ -1,3 +1,7 @@
+const shouldShowOriginalField = (original, translation) => {
+  return textUtils.hasText(original) || !textUtils.hasText(translation);
+};
+
 const DualField = Vue.defineComponent({
   name: 'DualField',
   props: {
@@ -48,35 +52,37 @@ const DualField = Vue.defineComponent({
   },
   emits: ['update:original', 'update:translation'],
   data() {
+    const hasInitialValue = textUtils.hasText(this.original) || textUtils.hasText(this.translation);
+
     return {
-      isOriginalVisible: !(!this.original && this.translation),
+      isOriginalVisible: shouldShowOriginalField(this.original, this.translation),
       localOriginal: this.original,
       localTranslation: this.translation,
-      hasAutoSelected: !!(this.original || this.translation),
+      hasSelectedInitialField: hasInitialValue,
     };
   },
   watch: {
     // Watch for prop changes and update local copies accordingly
     original(newVal) {
       this.localOriginal = newVal;
-      this.autoSelectVisibleField();
+      this.selectInitialVisibleField();
     },
     translation(newVal) {
       this.localTranslation = newVal;
-      this.autoSelectVisibleField();
+      this.selectInitialVisibleField();
     },
   },
   methods: {
     toggleField() {
       this.isOriginalVisible = !this.isOriginalVisible;
     },
-    autoSelectVisibleField() {
+    selectInitialVisibleField() {
       // Only runs once, the first time data arrives (e.g. async fetch after mount).
       // Skipped afterwards so it never overrides the user's manual toggle while editing.
-      if (this.hasAutoSelected) return;
-      if (!this.original && !this.translation) return;
-      this.hasAutoSelected = true;
-      this.isOriginalVisible = !(!this.original && this.translation);
+      if (this.hasSelectedInitialField) return;
+      if (!textUtils.hasText(this.original) && !textUtils.hasText(this.translation)) return;
+      this.hasSelectedInitialField = true;
+      this.isOriginalVisible = shouldShowOriginalField(this.original, this.translation);
     },
     setUnknown() {
       if (this.allowUnknown) {

--- a/enferno/static/js/components/UniField.js
+++ b/enferno/static/js/components/UniField.js
@@ -1,29 +1,48 @@
 const UniField = Vue.defineComponent({
   props: {
     caption: String,
-    english: String | Number,
-    arabic: String | Number,
+    english: {
+      type: [String, Number],
+      default: '',
+    },
+    arabic: {
+      type: [String, Number],
+      default: '',
+    },
     disableSpacing: Boolean
   },
   data() {
     return {
-      sw: this.english ? true : false,
+      showEnglish: textUtils.hasText(this.english),
     };
   },
+  computed: {
+    hasEnglish() {
+      return textUtils.hasText(this.english);
+    },
+    hasArabic() {
+      return textUtils.hasText(this.arabic);
+    },
+  },
+  methods: {
+    displayText(value) {
+      return textUtils.normalizeDisplayText(value);
+    },
+  },
   template: `
-    <v-list v-if="english || arabic"  variant="plain" :class="['d-flex align-center flex-grow-1', { 'mx-2 my-1 pa-2': !disableSpacing }]">
-      <template v-if="english && arabic">
+    <v-list v-if="hasEnglish || hasArabic"  variant="plain" :class="['d-flex align-center flex-grow-1', { 'mx-2 my-1 pa-2': !disableSpacing }]">
+      <template v-if="hasEnglish && hasArabic">
         <v-list-item :title="caption" density="compact" :class="{ 'px-0': disableSpacing }">
-          <v-sheet class="text-body-2">{{ sw ? english : arabic }}</v-sheet>
+          <v-sheet class="text-body-2">{{ displayText(showEnglish ? english : arabic) }}</v-sheet>
           <template #append>
-              <v-btn variant="text" size="x-small" icon="mdi-web" @click.stop="sw= !sw"></v-btn>
+              <v-btn variant="text" size="x-small" icon="mdi-web" @click.stop="showEnglish = !showEnglish"></v-btn>
           </template>
         </v-list-item>
       </template>
 
       <template v-else>
         <v-list-item :title="caption" density="compact" :class="{ 'px-0': disableSpacing }">
-          <v-sheet class="text-body-2">{{ english || arabic }}</v-sheet>
+          <v-sheet class="text-body-2">{{ displayText(hasEnglish ? english : arabic) }}</v-sheet>
         </v-list-item>
       </template>
     </v-list>

--- a/enferno/static/js/components/UniField.js
+++ b/enferno/static/js/components/UniField.js
@@ -16,7 +16,7 @@ const UniField = Vue.defineComponent({
         <v-list-item :title="caption" density="compact" :class="{ 'px-0': disableSpacing }">
           <v-sheet class="text-body-2">{{ sw ? english : arabic }}</v-sheet>
           <template #append>
-              <v-btn variant="text" size="x-small" icon="mdi-web" @click="sw= !sw"></v-btn>
+              <v-btn variant="text" size="x-small" icon="mdi-web" @click.stop="sw= !sw"></v-btn>
           </template>
         </v-list-item>
       </template>


### PR DESCRIPTION
## Description
Follow-up to #363. DualField.js always defaulted to the English input even when only Arabic had a value — now it picks the correct default (and self-corrects once if data loads async, without breaking manual toggling). The actors list "Name" column now reuses UniField to show/toggle both languages instead of English-only. Added .stop to UniField's toggle button so clicking it inside a table row doesn't also trigger the row click.

## How to Test
- Edit an actor with only name_ar set, no English — reopening the dialog should default to the Arabic input, not empty English.
- In the Actors list, find an actor with both names set — the Name column should show one language with a globe icon to toggle to the other, without triggering the row click.
- Confirm actors with only one language still display normally.

## Jira ID (if applicable)
[e.g., BYNT-123]
