### PR TITLE
Remove stale update progress dialog reference

### DIFF
--- a/enferno/admin/templates/nav-bar.html
+++ b/enferno/admin/templates/nav-bar.html
@@ -11,8 +11,7 @@
   <v-spacer></v-spacer>
 
   <template v-slot:append>
-    <update-banner @update-started="$refs.progressDialog && $refs.progressDialog.open()"></update-banner>
-    <update-progress-dialog ref="progressDialog"></update-progress-dialog>
+    <update-banner></update-banner>
     {% if config.OCR_PROVIDER == 'google_vision' %}
     <v-tooltip location="bottom">
       <template v-slot:activator="{ props }">


### PR DESCRIPTION
## Summary
- Removes the orphaned `update-progress-dialog` tag from the navbar
- Removes the unused `update-started` listener from `update-banner`
- Keeps the update availability banner intact

Updates are now performed via the CLI, so the old progress dialog component no longer exists and should not be referenced by the UI.

## How to Test
1. Open any admin page.
2. Confirm the browser console no longer shows a missing/unknown `update-progress-dialog` component warning.
3. Confirm there are no references to `update-progress-dialog`, `UpdateProgressDialog`