### PR TITLE
Allow label edits to round-trip the path fields

### DIFF
--- a/enferno/admin/validation/models.py
+++ b/enferno/admin/validation/models.py
@@ -829,6 +829,9 @@ class LabelValidationModel(StrictValidationModel):
     # sent by tree view edit (build_tree node shape), not used by from_json
     parent_label_id: Optional[int] = None
     children: Optional[List] = None
+    # computed by to_dict for hierarchy display, not used by from_json
+    path: Optional[str] = None
+    path_ar: Optional[str] = None
 
 
 class LabelRequestModel(BaseValidationModel):

--- a/tests/test_lookup_crud.py
+++ b/tests/test_lookup_crud.py
@@ -518,6 +518,26 @@ def test_lookup_search_by_translated_title(request, session, entity, list_url, f
     assert item.id in ids
 
 
+def test_label_update_accepts_its_own_serialization(request, session):
+    """The edit form PUTs back what to_dict returned, path fields included."""
+    from enferno.admin.models import Label
+
+    parent = Label(title="Parent")
+    session.add(parent)
+    session.commit()
+    label = Label(title="Child", parent_label_id=parent.id)
+    session.add(label)
+    session.commit()
+
+    payload = label.to_dict()
+    assert "path" in payload and "path_ar" in payload
+    payload["title"] = "Renamed"
+
+    client = request.getfixturevalue("admin_client")
+    resp = client.put(f"/admin/api/label/{label.id}", json={"item": payload}, headers=HEADERS)
+    assert resp.status_code == 200
+
+
 def test_label_mode2_includes_translated_title_and_path(session):
     from enferno.admin.models import Label
 


### PR DESCRIPTION
`Label.to_dict()` returns `path` / `path_ar` (added in #369), and the admin edit form PUTs that payload straight back. `LabelValidationModel` is strict, so every label edit fails with:

```
[path]: Extra field not allowed
[path_ar]: Extra field not allowed
```

Adds both to the same discard list that already carries `id`, `order`, `updated_at`, `parent_label_id` and `children`.

Reported by @apodacaduron on #378.

## Tests
- New regression test PUTs a label's own `to_dict()` back and expects 200 (fails with 400 without the fix).
- `uv run pytest`: 869 passed, 4 skipped.