### PR TITLE
Fix stale search typeahead debounce race

### DIFF
--- a/enferno/static/js/components/SearchField.js
+++ b/enferno/static/js/components/SearchField.js
@@ -53,7 +53,13 @@ const SearchField = Vue.defineComponent({
     items: [],
     searchQuery: '',
     _justSelected: false,
+    _searchRequestId: 0,
   }),
+  created() {
+    this.debouncedSearch = debounce(function (search, requestId) {
+      this.executeSearch(search, requestId);
+    }, 350);
+  },
   computed: {
     filteredItems() {
       if (typeof this.filterItems === 'function') {
@@ -108,10 +114,11 @@ const SearchField = Vue.defineComponent({
       return [parts[0], '…', parts[parts.length - 1]].join(' > ');
     },
     startSearch(search) {
+      const requestId = ++this._searchRequestId;
       this.loading = true;
-      this.debouncedSearch(search);
+      this.debouncedSearch(search, requestId);
     },
-    debouncedSearch: debounce(function (search) {
+    executeSearch(search, requestId) {
       api
         .get(this.api, {
           params: {
@@ -121,13 +128,17 @@ const SearchField = Vue.defineComponent({
           },
         })
         .then((response) => {
+          if (requestId !== this._searchRequestId) return;
           this.items = this._mergeSelected(response.data.items);
         })
-        .catch(console.error)
+        .catch((error) => {
+          if (requestId === this._searchRequestId) console.error(error);
+        })
         .finally(() => {
+          if (requestId !== this._searchRequestId) return;
           this.loading = false;
         });
-    }, 350),
+    },
     _mergeSelected(fetchedItems) {
       if (!this.multiple || !Array.isArray(this.modelValue) || !this.modelValue.length) {
         return fetchedItems;
@@ -167,8 +178,12 @@ const SearchField = Vue.defineComponent({
       }).catch(console.error);
     },
     onFocused(focused) {
-      if (focused) this.startSearch(this.searchQuery)
-      else this.loading = false
+      if (focused) {
+        if (this.searchQuery || !this.items.length) this.startSearch(this.searchQuery)
+      } else {
+        this._searchRequestId++;
+        this.loading = false
+      }
     }
   },
   watch: {
@@ -246,8 +261,7 @@ const SearchField = Vue.defineComponent({
 const LocationSearchField = Vue.defineComponent({
   extends: SearchField,
   methods: {
-    debouncedSearch: debounce(function (search) {
-      this.loading = true;
+    executeSearch(search, requestId) {
       api
         .post(this.api, {
           q: {
@@ -257,10 +271,14 @@ const LocationSearchField = Vue.defineComponent({
           options: {},
         })
         .then((response) => {
+          if (requestId !== this._searchRequestId) return;
           this.items = this._mergeSelected(response.data.items);
+        }).catch((error) => {
+          if (requestId === this._searchRequestId) console.error(error);
         }).finally(() => {
+          if (requestId !== this._searchRequestId) return;
           this.loading = false;
         });
-    }, 350),
+    },
   },
 });

--- a/enferno/static/js/components/SearchField.js
+++ b/enferno/static/js/components/SearchField.js
@@ -54,8 +54,11 @@ const SearchField = Vue.defineComponent({
     searchQuery: '',
     _justSelected: false,
     _searchRequestId: 0,
+    // Tracks which query produced items, so focus can refresh stale cached results.
+    _itemsSearchQuery: null,
   }),
   created() {
+    // Use a normal function so debounce forwards Vue's instance context.
     this.debouncedSearch = debounce(function (search, requestId) {
       this.executeSearch(search, requestId);
     }, 350);
@@ -130,6 +133,7 @@ const SearchField = Vue.defineComponent({
         .then((response) => {
           if (requestId !== this._searchRequestId) return;
           this.items = this._mergeSelected(response.data.items);
+          this._itemsSearchQuery = search;
         })
         .catch((error) => {
           if (requestId === this._searchRequestId) console.error(error);
@@ -179,7 +183,8 @@ const SearchField = Vue.defineComponent({
     },
     onFocused(focused) {
       if (focused) {
-        if (this.searchQuery || !this.items.length) this.startSearch(this.searchQuery)
+        // Refresh if retained/cached results no longer match the current query.
+        if (this.searchQuery || !this.items.length || this._itemsSearchQuery !== this.searchQuery) this.startSearch(this.searchQuery)
       } else {
         this._searchRequestId++;
         this.loading = false
@@ -273,6 +278,7 @@ const LocationSearchField = Vue.defineComponent({
         .then((response) => {
           if (requestId !== this._searchRequestId) return;
           this.items = this._mergeSelected(response.data.items);
+          this._itemsSearchQuery = search;
         }).catch((error) => {
           if (requestId === this._searchRequestId) console.error(error);
         }).finally(() => {


### PR DESCRIPTION
## Description
Fixes race conditions in shared search typeahead fields where older responses could overwrite newer, more specific results.

Each field now gets its own debounced search function, so typing in one field no longer cancels another field’s pending search. Search responses are also sequenced so stale responses are ignored. Location search uses the same behavior.

Focus handling was tightened to avoid unnecessary empty-query fetches while still refreshing cached results when the current query changes.

## How to Test
1. In Labels, Sources, or Locations, type a search term and quickly continue typing.
2. Confirm newer, more specific results are not replaced by older broad results.
3. Select an item, clear/reopen the field, and confirm the dropdown refreshes correctly.

## Jira ID (if applicable)
[BYNT-1765](https://syriajustice.atlassian.net/browse/BYNT-1765)


[BYNT-1765]: https://syriajustice.atlassian.net/browse/BYNT-1765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ