### PR TITLE
Expire stale Celery messages and guard notifications for missing users

### DIFF
--- a/enferno/admin/models/Notification.py
+++ b/enferno/admin/models/Notification.py
@@ -134,6 +134,14 @@ class Notification(db.Model, BaseMixin):
         link=None,
     ):
         """Create notification for a specific user"""
+        # A task holding a stale user id resolves to None. Bail out here rather
+        # than let it reach the NOT NULL on user_id, where the failure surfaces
+        # as an IntegrityError far from its cause. send_email defaults to False,
+        # so the short-circuit below would never dereference user either.
+        if user is None:
+            logger.warning(f"Skipping notification '{title}': target user no longer exists")
+            return None
+
         # Determine if email should be enabled
         email_enabled = send_email and bool(user.email) and Config.get("MAIL_ENABLED")
 

--- a/enferno/tasks/__init__.py
+++ b/enferno/tasks/__init__.py
@@ -63,6 +63,11 @@ def init_worker_process(**kwargs):
 # Class to run tasks within application's context
 class ContextTask(celery.Task):
     abstract = True
+    # Drop messages the broker has held for longer than a day. Task payloads
+    # carry row ids, so one queued against a database that has since moved on
+    # (a restored dump, a swapped dev DB) can only fail. Without this the
+    # backlog is immortal and re-runs on every worker start.
+    expires = 24 * 60 * 60
 
     def __call__(self, *args, **kwargs):
         global _flask_app

--- a/tests/test_celery_stale_tasks.py
+++ b/tests/test_celery_stale_tasks.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+"""Tests for stale-task defences: message expiry and missing-user guards."""
+
+from sqlalchemy import func, select
+
+from enferno.admin.models.Notification import Notification
+from enferno.extensions import db
+from enferno.tasks import ContextTask, celery
+
+
+class TestMessageExpiry:
+    def test_context_task_sets_expiry(self):
+        assert ContextTask.expires == 24 * 60 * 60
+
+    def test_expiry_applies_to_registered_tasks(self):
+        # celery.Task is ContextTask, so every @celery.task inherits the bound
+        task = celery.tasks["enferno.tasks.bulk_ops.bulk_update_actors"]
+        assert task.expires == 24 * 60 * 60
+
+
+class TestMissingUserGuard:
+    def test_create_for_user_skips_missing_user(self, app, session):
+        before = db.session.scalar(select(func.count()).select_from(Notification))
+
+        result = Notification.create_for_user(None, "Bulk Operation Status", "message body")
+
+        assert result is None
+        after = db.session.scalar(select(func.count()).select_from(Notification))
+        assert after == before, "a missing user must not write a notification row"


### PR DESCRIPTION
Starting a worker against a database that has moved on produces a flood of failing tasks. Two small guards stop it.

### Message expiry

Task payloads carry row ids. A message queued against a database that has since been restored, swapped, or rebuilt can only fail, but nothing expires it, so the backlog is immortal and re-runs in full on every worker start.

Observed locally: 228 queued `etl_process_file` messages referencing `data_import` ids up to 1825 against a database whose max id was 196. Every worker start drained all 228 into tracebacks.

`expires` on the existing `ContextTask` base covers every task at once, since `celery.Task = ContextTask`. A worker that picks up an expired message discards it instead of running it. 24h is deliberately generous so long imports and exports still fit.

### Missing-user guard

The same stale-payload problem in `bulk_ops`: `db.session.get(User, cur_user_id)` returns `None`, and `Notification(user=None)` then trips the `NOT NULL` on `notification.user_id`, surfacing as an `IntegrityError` from inside a commit, far from the actual cause.

It slips through because `send_email` defaults to `False`, so this line short-circuits before ever dereferencing `user`:

```python
email_enabled = send_email and bool(user.email) and Config.get("MAIL_ENABLED")
```

Returning `None` matches the function's existing contract, it already does exactly that when an event is disabled, and all callers discard the return value.

### Notes

A vanished row is an expected condition here, not an exception, so it logs at warning and returns rather than raising.

Not included, worth doing separately: `acks_late` and default time limits, both of which need tasks to be idempotent first and are a real design commitment rather than a flag flip.
