### PR TITLE
Document search timeout and background search settings

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -77,6 +77,16 @@ BACKUPS_AWS_ACCESS_KEY_ID=''
 BACKUPS_AWS_SECRET_ACCESS_KEY=''
 BACKUPS_AWS_REGION=''
 
+# Search
+# Interactive searches run under a database statement timeout, in seconds.
+# When a search exceeds it, the query is cancelled and handed to a background
+# worker instead of failing, and the user is notified when results are ready.
+# Set to 0 to disable, searches then run unbounded. Default 30.
+# SEARCH_TIMEOUT=30
+# Upper bound, in seconds, for the background re-run of a timed-out search.
+# Default 600.
+# BACKGROUND_SEARCH_TIME_LIMIT=600
+
 # OCR provider configuration (provider, Google Vision key, LLM endpoint/model/key)
 # is managed through the System Administration dashboard. The environment
 # variables below are honored as an escape hatch and, when set, override the

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -86,6 +86,21 @@ Media files stored in `enferno/media/`.
 
 Configure the S3 bucket with correct policies, block public access, and set up CORS.
 
+## Search
+
+Interactive searches run under a database statement timeout. When a search exceeds it, the query is cancelled and re-run by a background worker instead of failing, and the user is notified when the results are ready. See [Search](/guide/search) for what this looks like in the interface.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `SEARCH_TIMEOUT` | `30` | Seconds an interactive search may run before it is handed to the background. `0` disables the behaviour and searches run unbounded. |
+| `BACKGROUND_SEARCH_TIME_LIMIT` | `600` | Seconds the background re-run may take before it is abandoned. |
+
+Background searches require a running Celery worker. Without one, users receive the "continuing in the background" message but never get results.
+
+::: warning
+Lowering `SEARCH_TIMEOUT` far below the default sends ordinary searches to the background, including the initial page load of a list view. Raise it instead if legitimate searches are being deferred.
+:::
+
 ## Data Import
 
 Enable path scanning with `ETL_ALLOWED_PATH`.

--- a/docs/guide/search.md
+++ b/docs/guide/search.md
@@ -50,6 +50,21 @@ Locations support hierarchical search. Selecting a parent location (e.g., a gove
 
 This is useful for queries that can't be expressed in a single search, such as "Bulletins from Damascus OR Aleppo that mention detention AND are assigned to me."
 
+## Long-Running Searches
+
+Searches over large datasets can take longer than the server allows for an interactive request. Rather than failing, these continue in the background.
+
+When this happens:
+
+1. A message appears saying the search is continuing in the background
+2. The search is re-run by a background worker without the interactive time limit
+3. A notification arrives when the results are ready
+4. Opening the notification returns you to the list with the results applied
+
+Results stay available for 24 hours, after which the notification link expires. Very large result sets are capped, and the notification shows a `+` after the count when this happens.
+
+Administrators can adjust the threshold, see [Configuration](/deployment/configuration).
+
 ## Saved Searches
 
 Save current search parameters for quick reuse:


### PR DESCRIPTION
#372 introduced two settings that were not documented anywhere: not in `.env-sample`, not in `.env.docker`, not in the docs. An operator upgrading has no way to discover that `SEARCH_TIMEOUT` exists or that it now defaults to 30 seconds, which changes how every slow search behaves.

`SESSION_LIFETIME` is the cautionary precedent here, also `.env`-only and undocumented, which made it needlessly hard to find when it needed tuning in production.

### Changes

- **`.env-sample`** — both settings as commented entries with their defaults, matching how the file already handles optional configuration.
- **`docs/deployment/configuration.md`** — a `## Search` section next to the other per-concern sections, with a table of both variables and a warning that lowering the threshold too far pushes ordinary list views into the background.
- **`docs/guide/search.md`** — a user-facing `## Long-Running Searches` section covering what actually happens: the message, the notification, the 24h result window, and the `+` shown when a large result set is capped.

Docs only, no code changes.

### Note

The configuration page states that background searches need a running Celery worker. Without one the user gets the "continuing in the background" message and never receives results, which is silent and confusing enough to be worth documenting explicitly.
