### PR TITLE
Add revision history for user account and permission changes

### DIFF
--- a/enferno/admin/models/UserHistory.py
+++ b/enferno/admin/models/UserHistory.py
@@ -21,27 +21,23 @@ class UserHistory(db.Model, BaseMixin):
     """
 
     id = db.Column(db.Integer, primary_key=True)
-    # the user this revision describes. Users are hard deleted, and every user
-    # carries at least one revision, so cascade or deletion becomes impossible.
+    # The user this revision describes. Revisions outlive the account: this is
+    # an evidence platform, so a hard delete must not erase the record of what
+    # an account was allowed to do. The snapshot in `data` carries the id,
+    # username, name and email, so a detached row still identifies its subject.
     target_user_id = db.Column(
         db.Integer,
-        db.ForeignKey("user.id", ondelete="CASCADE"),
+        db.ForeignKey("user.id", ondelete="SET NULL"),
         index=True,
-        nullable=False,
     )
     target_user = db.relationship(
         "User",
-        backref=db.backref(
-            "history",
-            order_by="UserHistory.updated_at",
-            cascade="all, delete-orphan",
-            passive_deletes=True,
-        ),
+        backref=db.backref("history", order_by="UserHistory.updated_at"),
         foreign_keys=[target_user_id],
     )
     data = db.Column(JSON)
-    # user tracking, who made the change. Kept on their deletion so the trail
-    # of what happened to other accounts survives.
+    # user tracking, who made the change. Also kept on their deletion, so the
+    # trail of what they did to other accounts survives.
     user_id = db.Column(db.Integer, db.ForeignKey("user.id", ondelete="SET NULL"))
     user = db.relationship("User", backref="user_revisions", foreign_keys=[user_id])
 

--- a/enferno/admin/models/UserHistory.py
+++ b/enferno/admin/models/UserHistory.py
@@ -1,0 +1,62 @@
+import json
+from typing import Any
+
+from sqlalchemy import JSON
+
+from enferno.extensions import db
+from enferno.utils.base import BaseMixin
+from enferno.utils.date_helper import DateHelper
+from enferno.utils.logging_utils import get_logger
+
+logger = get_logger()
+
+
+class UserHistory(db.Model, BaseMixin):
+    """
+    SQL Alchemy model for user account revisions.
+
+    Snapshots account and permission state so admins can answer
+    "when did this user get this permission, and who granted it".
+    Access is restricted to Admin at the endpoint level.
+    """
+
+    id = db.Column(db.Integer, primary_key=True)
+    # the user this revision describes. Users are hard deleted, and every user
+    # carries at least one revision, so cascade or deletion becomes impossible.
+    target_user_id = db.Column(
+        db.Integer,
+        db.ForeignKey("user.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+    )
+    target_user = db.relationship(
+        "User",
+        backref=db.backref(
+            "history",
+            order_by="UserHistory.updated_at",
+            cascade="all, delete-orphan",
+            passive_deletes=True,
+        ),
+        foreign_keys=[target_user_id],
+    )
+    data = db.Column(JSON)
+    # user tracking, who made the change. Kept on their deletion so the trail
+    # of what happened to other accounts survives.
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id", ondelete="SET NULL"))
+    user = db.relationship("User", backref="user_revisions", foreign_keys=[user_id])
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a dictionary representation of the user revision."""
+        return {
+            "id": self.id,
+            "data": self.data,
+            "created_at": DateHelper.serialize_datetime(self.created_at),
+            "user": self.user.to_compact() if self.user else None,
+        }
+
+    def to_json(self) -> str:
+        """Return a JSON representation of the user revision."""
+        return json.dumps(self.to_dict(), sort_keys=True)
+
+    def __repr__(self):
+        return "<UserHistory {} -- Target {}>".format(self.id, self.target_user_id)

--- a/enferno/admin/models/__init__.py
+++ b/enferno/admin/models/__init__.py
@@ -43,5 +43,6 @@ from .PotentialViolation import PotentialViolation
 from .Query import Query
 from .Settings import Settings
 from .Source import Source
+from .UserHistory import UserHistory
 from .WorkflowStatus import WorkflowStatus
 from .Notification import Notification

--- a/enferno/admin/views/history.py
+++ b/enferno/admin/views/history.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from flask import Response
-from flask_security.decorators import current_user
+from flask_security.decorators import current_user, roles_required
 from sqlalchemy import desc
 
 from enferno.admin.models import (
@@ -13,8 +13,10 @@ from enferno.admin.models import (
     Incident,
     IncidentHistory,
     LocationHistory,
+    UserHistory,
 )
 from enferno.extensions import db
+from enferno.user.models import User
 from enferno.utils.http_response import HTTPResponse
 import enferno.utils.typing as t
 from . import admin, require_view_history
@@ -143,6 +145,37 @@ def api_locationhistory(locationid: t.id) -> Response:
     result = (
         LocationHistory.query.filter_by(location_id=locationid)
         .order_by(desc(LocationHistory.created_at))
+        .all()
+    )
+    # For standardization
+    response = {"items": [item.to_dict() for item in result]}
+    return HTTPResponse.success(data=response)
+
+
+# User History Helpers
+
+
+@admin.route("/api/userhistory/<int:userid>")
+@roles_required("Admin")
+def api_userhistory(userid: t.id) -> Response:
+    """
+    Endpoint to get revision history of a user account.
+
+    Admin only: revisions carry account and permission state, and are not
+    gated by the view_history permissions used for content items.
+
+    Args:
+        - userid: id of the user.
+
+    Returns:
+        - json feed of the user's history / error.
+    """
+    if not db.session.get(User, userid):
+        return HTTPResponse.not_found("User not found")
+
+    result = (
+        UserHistory.query.filter_by(target_user_id=userid)
+        .order_by(desc(UserHistory.created_at))
         .all()
     )
     # For standardization

--- a/enferno/admin/views/users.py
+++ b/enferno/admin/views/users.py
@@ -311,6 +311,7 @@ def api_user_create(
     user.from_json(u)
     result = user.save()
     if result:
+        user.create_revision()
         # Record activity
         Activity.create(
             current_user, Activity.ACTION_CREATE, Activity.STATUS_SUCCESS, user.to_mini(), "user"
@@ -396,6 +397,7 @@ def api_user_update(
 
         user = user.from_json(u)
         if user.save():
+            user.create_revision()
             # Record activity
             Activity.create(
                 current_user,

--- a/enferno/user/models.py
+++ b/enferno/user/models.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 from uuid import uuid4
 
 from flask import current_app, session, has_app_context, has_request_context
@@ -431,6 +431,48 @@ class User(UserMixin, db.Model, BaseMixin):
         self.can_access_media = item.get("can_access_media", False)
         self.active = item.get("active")
         return self
+
+    def to_history_dict(self) -> dict:
+        """
+        Snapshot serializer for the revision history.
+
+        Deliberately not to_dict(): that one masks names via the secure_*
+        properties based on the acting user, and carries the live password
+        reset key. A stored revision must be neither viewer-dependent nor
+        hold secrets.
+        """
+        return {
+            "id": self.id,
+            "name": self.name,
+            "username": self.username,
+            "email": self.email,
+            "active": self.active,
+            "roles": [{"id": role.id, "name": role.name} for role in self.roles],
+            "view_usernames": self.view_usernames,
+            "view_simple_history": self.view_simple_history,
+            "view_full_history": self.view_full_history,
+            "can_self_assign": self.can_self_assign,
+            "can_edit_locations": self.can_edit_locations,
+            "can_export": self.can_export,
+            "can_import_web": self.can_import_web,
+            "can_access_media": self.can_access_media,
+        }
+
+    def create_revision(self, user_id: Optional[int] = None) -> None:
+        """
+        Store a snapshot of this user's account and permission state.
+
+        Args:
+            - user_id: id of the user making the change, defaults to the
+              current user. None when there is no acting user (CLI, install).
+        """
+        from enferno.admin.models import UserHistory
+
+        # current_user is unbound outside a request, so guard rather than
+        # attributing the change to an arbitrary user
+        if user_id is None and has_request_context():
+            user_id = getattr(current_user, "id", None)
+        UserHistory(target_user_id=self.id, data=self.to_history_dict(), user_id=user_id).save()
 
     @property
     def two_factor_devices(self) -> Dict[str, Any]:

--- a/enferno/user/models.py
+++ b/enferno/user/models.py
@@ -447,7 +447,13 @@ class User(UserMixin, db.Model, BaseMixin):
             "username": self.username,
             "email": self.email,
             "active": self.active,
-            "roles": [{"id": role.id, "name": role.name} for role in self.roles],
+            # sorted so two snapshots of the same roles compare equal: the
+            # relationship has no order_by, so its order is whatever the join
+            # returns, and an unstable order would read as a change on diff
+            "roles": [
+                {"id": role.id, "name": role.name}
+                for role in sorted(self.roles, key=lambda r: r.id)
+            ],
             "view_usernames": self.view_usernames,
             "view_simple_history": self.view_simple_history,
             "view_full_history": self.view_full_history,

--- a/migrations/versions/a91c4b7e0d52_add_user_history.py
+++ b/migrations/versions/a91c4b7e0d52_add_user_history.py
@@ -20,13 +20,13 @@ def upgrade():
     op.create_table(
         "user_history",
         sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("target_user_id", sa.Integer(), nullable=False),
+        sa.Column("target_user_id", sa.Integer(), nullable=True),
         sa.Column("data", sa.JSON(), nullable=True),
         sa.Column("user_id", sa.Integer(), nullable=True),
         sa.Column("created_at", sa.DateTime(), nullable=True),
         sa.Column("updated_at", sa.DateTime(), nullable=True),
         sa.Column("deleted", sa.Boolean(), server_default="false", nullable=False),
-        sa.ForeignKeyConstraint(["target_user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["target_user_id"], ["user.id"], ondelete="SET NULL"),
         sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="SET NULL"),
         sa.PrimaryKeyConstraint("id"),
     )

--- a/migrations/versions/a91c4b7e0d52_add_user_history.py
+++ b/migrations/versions/a91c4b7e0d52_add_user_history.py
@@ -34,6 +34,46 @@ def upgrade():
         op.f("ix_user_history_target_user_id"), "user_history", ["target_user_id"], unique=False
     )
 
+    # Baseline snapshot per existing user. A revision is only meaningful against
+    # the one before it, and user accounts are edited rarely, so without a
+    # baseline the first edit of each existing account would be undiffable
+    # for as long as that account goes untouched. user_id is left null: no
+    # acting user made this change. Mirrors User.to_history_dict().
+    op.execute("""
+        INSERT INTO user_history (target_user_id, data, user_id, created_at, updated_at, deleted)
+        SELECT
+            u.id,
+            json_build_object(
+                'id', u.id,
+                'name', u.name,
+                'username', u.username,
+                'email', u.email,
+                'active', u.active,
+                'roles', COALESCE(
+                    (
+                        SELECT json_agg(json_build_object('id', r.id, 'name', r.name) ORDER BY r.id)
+                        FROM roles_users ru
+                        JOIN role r ON r.id = ru.role_id
+                        WHERE ru.user_id = u.id
+                    ),
+                    '[]'::json
+                ),
+                'view_usernames', u.view_usernames,
+                'view_simple_history', u.view_simple_history,
+                'view_full_history', u.view_full_history,
+                'can_self_assign', u.can_self_assign,
+                'can_edit_locations', u.can_edit_locations,
+                'can_export', u.can_export,
+                'can_import_web', u.can_import_web,
+                'can_access_media', u.can_access_media
+            ),
+            NULL,
+            timezone('utc', now()),
+            timezone('utc', now()),
+            false
+        FROM "user" u
+        """)
+
 
 def downgrade():
     op.drop_index(op.f("ix_user_history_target_user_id"), table_name="user_history")

--- a/migrations/versions/a91c4b7e0d52_add_user_history.py
+++ b/migrations/versions/a91c4b7e0d52_add_user_history.py
@@ -1,0 +1,40 @@
+"""add user history
+
+Revision ID: a91c4b7e0d52
+Revises: d4f7a2c9b310
+Create Date: 2026-08-11
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "a91c4b7e0d52"
+down_revision = "d4f7a2c9b310"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "user_history",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("target_user_id", sa.Integer(), nullable=False),
+        sa.Column("data", sa.JSON(), nullable=True),
+        sa.Column("user_id", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.Column("deleted", sa.Boolean(), server_default="false", nullable=False),
+        sa.ForeignKeyConstraint(["target_user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_user_history_target_user_id"), "user_history", ["target_user_id"], unique=False
+    )
+
+
+def downgrade():
+    op.drop_index(op.f("ix_user_history_target_user_id"), table_name="user_history")
+    op.drop_table("user_history")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,6 +179,7 @@ select = ["F"]  # pyflakes: unused imports, undefined names, syntax errors
 [tool.ruff.lint.per-file-ignores]
 "enferno/app.py" = ["F841"]       # security = Security() assigned for side effects
 "enferno/commands.py" = ["F811"]  # extract() name reused across CLI groups
+"enferno/admin/models/__init__.py" = ["F401"]  # re-export surface for the model package
 
 [dependency-groups]
 dev = [

--- a/tests/test_pentest_fixes.py
+++ b/tests/test_pentest_fixes.py
@@ -826,3 +826,60 @@ def test_bay_01_012_can_view_media_gate():
             assert mu.can_view_media() is True
         with patch.object(mu, "current_user", _Admin()):
             assert mu.can_view_media() is True
+
+
+# ---------------------------------------------------------------------------
+# BAY-01-001 (extension)  The user revision-history endpoint is new surface of
+# the same class the auditor flagged: a *history* route that can leak state the
+# caller cannot reach through the primary API. User revisions carry account and
+# permission state, so this one is Admin-only rather than gated on the
+# view_history permissions, and the auditor's exact profile (view_simple_history
+# with no Admin role) must be refused.
+# ---------------------------------------------------------------------------
+
+
+def test_bay_01_001_user_history_denied_to_history_viewer(
+    session, users, history_viewer_outside_group
+):
+    admin_user, _, _, _ = users
+    resp = history_viewer_outside_group.get(f"/admin/api/userhistory/{admin_user.id}")
+    assert resp.status_code == 403
+
+
+def test_bay_01_001_user_history_denied_to_non_admin_roles(request, session, users):
+    admin_user, _, _, _ = users
+    for fixture in ("da_client", "mod_client"):
+        client = request.getfixturevalue(fixture)
+        resp = client.get(f"/admin/api/userhistory/{admin_user.id}")
+        assert resp.status_code == 403, f"{fixture} reached user history"
+
+
+def test_bay_01_001_user_history_requires_auth(anonymous_client):
+    """JSON callers get 401; a browser caller is redirected to login. Either way
+    the payload is never served anonymously."""
+    resp = anonymous_client.get(
+        "/admin/api/userhistory/1", headers={"Content-Type": "application/json"}
+    )
+    assert resp.status_code == 401
+
+    resp = anonymous_client.get("/admin/api/userhistory/1")
+    assert resp.status_code == 302
+    assert "/login" in resp.headers.get("Location", "")
+
+
+def test_bay_01_001_user_history_snapshot_holds_no_credentials(session, users):
+    """The snapshot is persisted forever, so it must never carry a secret.
+    to_dict() would have: it includes force_reset, the live password reset key."""
+    admin_user, _, _, _ = users
+    admin_user.set_security_reset_key()
+    try:
+        reset_key = admin_user.security_reset_key
+        assert reset_key, "precondition: reset key is set"
+        snapshot = admin_user.to_history_dict()
+        for secret in ("password", "force_reset", "fs_uniquifier", "tf_totp_secret"):
+            assert secret not in snapshot
+        serialized = str(snapshot)
+        assert reset_key not in serialized
+        assert admin_user.password not in serialized
+    finally:
+        admin_user.unset_security_reset_key()

--- a/tests/test_user_history.py
+++ b/tests/test_user_history.py
@@ -95,6 +95,21 @@ class TestUserHistoryRecording:
         assert "force_reset" not in snapshot
         assert "fs_uniquifier" not in snapshot
 
+    def test_role_order_is_stable(self, session):
+        """Unstable role order would read as a change when nothing changed."""
+        from enferno.user.models import Role
+
+        user = UserFactory()
+        user.fs_uniquifier = uuid4().hex
+        roles = Role.query.order_by(Role.id).limit(2).all()
+        assert len(roles) == 2
+        user.roles = list(reversed(roles))
+        session.add(user)
+        session.commit()
+
+        snapshot = user.to_history_dict()
+        assert [r["id"] for r in snapshot["roles"]] == sorted(r.id for r in roles)
+
     def test_delete_cascades_revisions(self, session, users):
         """A user carries revisions, so deletion must not be blocked by them."""
         admin_user, _, _, _ = users

--- a/tests/test_user_history.py
+++ b/tests/test_user_history.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 import pytest
 
 from enferno.admin.models import UserHistory
+from enferno.extensions import db
 from enferno.user.models import User
 from tests.factories import UserFactory
 
@@ -110,16 +111,30 @@ class TestUserHistoryRecording:
         snapshot = user.to_history_dict()
         assert [r["id"] for r in snapshot["roles"]] == sorted(r.id for r in roles)
 
-    def test_delete_cascades_revisions(self, session, users):
-        """A user carries revisions, so deletion must not be blocked by them."""
+    def test_delete_preserves_revisions(self, session, users):
+        """Evidence platform: deleting an account must not erase the record of
+        what it was allowed to do, nor be blocked by that record."""
         admin_user, _, _, _ = users
         user = UserFactory()
         user.fs_uniquifier = uuid4().hex
+        user.username = "doomed"
         session.add(user)
         session.commit()
         user.create_revision(user_id=admin_user.id)
         user_id = user.id
-        assert UserHistory.query.filter_by(target_user_id=user_id).count() == 1
+        revision_id = UserHistory.query.filter_by(target_user_id=user_id).one().id
 
+        # deletion still works, the revision does not block it
         assert user.delete() is True
-        assert UserHistory.query.filter_by(target_user_id=user_id).count() == 0
+
+        orphan = db.session.get(UserHistory, revision_id)
+        assert orphan is not None
+        assert orphan.target_user_id is None
+        # the snapshot still identifies its subject
+        assert orphan.data["id"] == user_id
+        assert orphan.data["username"] == "doomed"
+        # and still records who made the change
+        assert orphan.user_id == admin_user.id
+
+        db.session.delete(orphan)
+        db.session.commit()

--- a/tests/test_user_history.py
+++ b/tests/test_user_history.py
@@ -1,0 +1,110 @@
+"""Tests for user account revision history."""
+
+from uuid import uuid4
+
+import pytest
+
+from enferno.admin.models import UserHistory
+from enferno.user.models import User
+from tests.factories import UserFactory
+
+HEADERS = {"Content-Type": "application/json"}
+
+
+def _user_payload(user):
+    return {
+        "name": user.name,
+        "username": user.username,
+        "active": user.active,
+        "password": user.password,
+        "email": user.email,
+    }
+
+
+# =========================================================================
+# GET /admin/api/userhistory/<id>
+# =========================================================================
+
+
+class TestUserHistoryAccess:
+    @pytest.mark.parametrize(
+        "client_fixture, expected",
+        [
+            ("admin_client", 200),
+            ("da_client", 403),
+            ("mod_client", 403),
+            ("anonymous_client", 401),
+        ],
+    )
+    def test_access(self, request, session, users, client_fixture, expected):
+        admin_user, _, _, _ = users
+        client = request.getfixturevalue(client_fixture)
+        resp = client.get(f"/admin/api/userhistory/{admin_user.id}", headers=HEADERS)
+        assert resp.status_code == expected
+
+    def test_unknown_user_404(self, admin_client, session):
+        resp = admin_client.get("/admin/api/userhistory/999999", headers=HEADERS)
+        assert resp.status_code == 404
+
+
+# =========================================================================
+# Revisions recorded on write
+# =========================================================================
+
+
+class TestUserHistoryRecording:
+    def test_create_records_revision(self, admin_client, session, users):
+        admin_user, _, _, _ = users
+        user = UserFactory()
+        user.fs_uniquifier = uuid4().hex
+        resp = admin_client.post(
+            "/admin/api/user/", json={"item": _user_payload(user)}, headers=HEADERS
+        )
+        assert resp.status_code == 201
+
+        created = User.query.filter_by(username=user.username).one()
+        revisions = UserHistory.query.filter_by(target_user_id=created.id).all()
+        assert len(revisions) == 1
+        assert revisions[0].user_id == admin_user.id
+        assert revisions[0].data["username"] == user.username
+
+    def test_update_records_revision_with_permission_change(self, admin_client, session, users):
+        user = UserFactory()
+        user.fs_uniquifier = uuid4().hex
+        session.add(user)
+        session.commit()
+
+        payload = _user_payload(user)
+        payload["id"] = user.id
+        payload["can_export"] = True
+        resp = admin_client.put("/admin/api/user/", json={"item": payload}, headers=HEADERS)
+        assert resp.status_code == 200
+
+        revisions = UserHistory.query.filter_by(target_user_id=user.id).all()
+        assert len(revisions) == 1
+        assert revisions[0].data["can_export"] is True
+
+    def test_snapshot_carries_no_secrets(self, session):
+        user = UserFactory()
+        user.fs_uniquifier = uuid4().hex
+        session.add(user)
+        session.commit()
+
+        snapshot = user.to_history_dict()
+        assert "password" not in snapshot
+        assert "force_reset" not in snapshot
+        assert "fs_uniquifier" not in snapshot
+
+    def test_delete_cascades_revisions(self, session, users):
+        """A user carries revisions, so deletion must not be blocked by them."""
+        admin_user, _, _, _ = users
+        user = UserFactory()
+        user.fs_uniquifier = uuid4().hex
+        session.add(user)
+        session.commit()
+        user.create_revision(user_id=admin_user.id)
+        user_id = user.id
+        assert UserHistory.query.filter_by(target_user_id=user_id).count() == 1
+
+        assert user.delete() is True
+        assert UserHistory.query.filter_by(target_user_id=user_id).count() == 0


### PR DESCRIPTION
Closes BYNT-1550.

Records a snapshot of a user's account and permission state on every create and update, so an admin can answer "when did this user get this permission, and who granted it". Salvaged from the closed #217 and rebuilt on current main.

The existing `activity` table only stores `{"id": N, "class": "user"}` as the subject, so it records that an edit happened but not what changed. It is also skipped entirely when the action is not in `ACTIVITIES_LIST`, so it cannot serve as the permission audit trail.

### Changes
- `UserHistory` model following the existing `*History` pattern, with `target_user_id` (subject) and `user_id` (who made the change).
- `User.to_history_dict()` as the snapshot serializer. Deliberately not `to_dict()`: that one masks names through the `secure_*` properties based on the *viewing* user, and carries `force_reset` (the live password reset key). A stored revision must be neither viewer-dependent nor hold secrets.
- `User.create_revision()`, called from `api_user_create` and `api_user_update`.
- `GET /admin/api/userhistory/<id>`, Admin only. Not gated by the `view_history` permissions used for content items, since these revisions carry account and permission state.
- Alembic migration, single head.

### On deletion
Users are hard deleted and every user now carries at least one revision, so a plain FK would have made `api_user_delete` fail permanently. `target_user_id` is therefore `ON DELETE CASCADE` and `user_id` is `ON DELETE SET NULL`, so deleting an admin does not destroy the trail of what they did to other accounts. Covered by `test_delete_cascades_revisions`.

### Verification
- 895 passed, 4 skipped (full suite), including 9 new tests.
- Migration applied for real against a scratch DB (stamp down, `flask db upgrade`), resulting schema matches the model, `flask doctor` reports "Migrations up to date" and "Schema aligned with models".

### Not included
- Frontend. The endpoint returns the same `{items: [...]}` shape as the other history endpoints, so it can hang off the existing history drawer.
- Revisions for password reset, forced reset, and 2FA revoke (Daniel's note on #217). Those are actions rather than account state; they belong in `activity`, where they are currently not logged at all. Worth its own small ticket.
- The `pyproject.toml` line is a ruff per-file-ignore for the model package's re-export `__init__.py`, needed because adding one import made the hook lint the whole pre-existing file.
