### PR TITLE
Replay session-expired requests after re-authentication

### DIFF
--- a/enferno/admin/templates/admin/roles.html
+++ b/enferno/admin/templates/admin/roles.html
@@ -280,7 +280,9 @@
                         this.imDialog = false;
                         this.refresh();
                         this.showSnack(response.data);
-                    })
+                    }).catch(error => {
+                        this.showSnack(error?.response?.data);
+                    });
                 },
 
                 newItem() {
@@ -323,12 +325,13 @@
 
                 save() {
                     if (!this.isNewRecord) {
-                        Object.assign(this.items[this.editedIndex], this.editedItem);
                         api.put(`/admin/api/role/${this.editedItem.id}`, {item: this.editedItem})
                             .then(response => {
                                 this.showSnack(response.data);
                                 this.refresh()
                                 this.close();
+                            }).catch(error => {
+                                this.showSnack(error?.response?.data);
                             });
                     } else {
                         api
@@ -337,6 +340,8 @@
                                 this.showSnack(response.data);
                                 this.refresh()
                                 this.close()
+                            }).catch(error => {
+                                this.showSnack(error?.response?.data);
                             });
                     }
                 }

--- a/enferno/admin/templates/admin/roles.html
+++ b/enferno/admin/templates/admin/roles.html
@@ -33,7 +33,7 @@
 
                                         >{{ _('New Group') }}</v-btn>
 
-                                        <v-dialog v-model="dialog" max-width="770px" @after-leave="resetState()">
+                                        <v-dialog v-model="dialog" max-width="770px" @after-leave="resetGroupFormState()">
                                             <v-card>
                                                 <v-card-title class="px-5 py-7">
                                                     <span class="headline">${ formTitle }</span>
@@ -316,7 +316,7 @@
                     this.dialog = false;
                 },
 
-                resetState() {
+                resetGroupFormState() {
                     this.dialog = false;
                     this.editedItem = Object.assign({}, this.defaultItem);
                     this.editedIndex = -1;

--- a/enferno/admin/templates/admin/system-administration.html
+++ b/enferno/admin/templates/admin/system-administration.html
@@ -1432,7 +1432,6 @@
                     }).catch(e => {
                         console.error(e);
                         this.overlay = false;
-                        this.addToCallbackQueueIfReauthRequired(e, this.saveConfiguration);
                     }).finally(() => {
                         this.closeSaveDialog()
                     })

--- a/enferno/admin/templates/admin/system-administration.html
+++ b/enferno/admin/templates/admin/system-administration.html
@@ -1429,11 +1429,10 @@
                     this.preprocessConfig();
                     api.put('/admin/api/configuration/', {conf: this.eitem}).then(res => {
                         this.reloadApp();
+                        this.closeSaveDialog();
                     }).catch(e => {
                         console.error(e);
                         this.overlay = false;
-                    }).finally(() => {
-                        this.closeSaveDialog()
                     })
                 },
 

--- a/enferno/admin/templates/admin/users.html
+++ b/enferno/admin/templates/admin/users.html
@@ -565,7 +565,10 @@
 
                 checkUsername:
                     debounce(function (evt) {
-                        api.post('/admin/api/checkuser/', {item: this.editedItem.username}, { suppressGlobalErrorHandler: true }).then(
+                        api.post('/admin/api/checkuser/', {item: this.editedItem.username}, {
+                            suppressGlobalErrorHandler: true,
+                            suppressSessionReplay: true
+                        }).then(
                             res => {
 
                             }

--- a/enferno/admin/views/dynamic_fields.py
+++ b/enferno/admin/views/dynamic_fields.py
@@ -315,8 +315,13 @@ def api_session_check() -> Response:
     Lightweight endpoint to check if current session is still valid.
     Used by frontend to detect when session is restored after expiration.
 
+    Username is included so a tab can tell its own session being restored
+    apart from a *different* account having signed in on the same browser
+    (shared cookie jar) - the latter must not be treated as this tab's
+    session coming back.
+
     Returns:
         - 200: Session is valid
         - 401: Session expired (handled by auth decorator)
     """
-    return jsonify({"status": "valid"})
+    return jsonify({"status": "valid", "username": current_user.username})

--- a/enferno/static/js/common/config.js
+++ b/enferno/static/js/common/config.js
@@ -307,18 +307,72 @@ axios.defaults.headers.common['Accept'] = 'application/json';
 // Centralized API service - handles standardized responses transparently
 const api = {
     get: axios.get.bind(axios),
-    post: axios.post.bind(axios), 
+    post: axios.post.bind(axios),
     put: axios.put.bind(axios),
     delete: axios.delete.bind(axios)
 };
 
-//global axios response interceptor - handles standardized API responses and global error handling  
+// Requests whose own 401 must never be queued for replay: the auth endpoints
+// themselves (replaying a failed login makes no sense), and the session-check
+// probe used to test whether a session is alive again.
+const SESSION_REPLAY_EXCLUDED_PATHS = [
+    '/login',
+    '/verify',
+    '/tf-validate',
+    '/tf-select',
+    '/wan-signin',
+    '/csrf',
+    '/admin/api/session-check',
+];
+
+// Requests whose 401 must open the sign-in dialog but never be queued: the
+// silent notification poll marks itself so its failures don't get replayed
+// as a user-visible retried call once the user signs back in.
+function isSilentPollRequest(config) {
+    const headers = config?.headers;
+    if (!headers) return false;
+    if (typeof headers.get === 'function') return Boolean(headers.get('X-Silent-Poll'));
+    return Boolean(headers['X-Silent-Poll'] || headers['x-silent-poll']);
+}
+
+function isReplayExcluded(config) {
+    if (!config) return true;
+    if (config._sessionReplayed) return true;
+    if (isSilentPollRequest(config)) return true;
+    const url = config.url || '';
+    return SESSION_REPLAY_EXCLUDED_PATHS.some(path => url === path || url.startsWith(`${path}/`) || url.startsWith(`${path}?`));
+}
+
+// Requests dropped by a 401 mid-flight are queued here instead of being
+// rejected immediately, so a successful sign-in can replay them exactly
+// once and settle the original caller with the real outcome.
+const sessionReplayQueue = [];
+
+function queueForSessionReplay(config) {
+    return new Promise((resolve, reject) => {
+        sessionReplayQueue.push({ config, resolve, reject });
+    });
+}
+
+async function drainSessionReplayQueue() {
+    const pending = sessionReplayQueue.splice(0, sessionReplayQueue.length);
+    for (const { config, resolve, reject } of pending) {
+        try {
+            const replayConfig = { ...config, _sessionReplayed: true };
+            resolve(await axios.request(replayConfig));
+        } catch (error) {
+            reject(error);
+        }
+    }
+}
+
+//global axios response interceptor - handles standardized API responses and global error handling
 axios.interceptors.response.use(
     function (response) {
         const shouldFlatten =
             isPlainObject(response?.data?.data) &&
             !response?.config?.skipFlattening;
-    
+
         if (shouldFlatten) {
             return {
                 ...response,
@@ -328,18 +382,27 @@ axios.interceptors.response.use(
                 }
             };
         }
-    
+
       return response;
     },
     function (error) {
-        if (!error.config?.suppressGlobalErrorHandler) {
+        const isSessionExpiry = error?.response?.status === 401;
+        // A request about to be queued for replay isn't a failure yet, so
+        // it must not surface an error toast ahead of the real outcome.
+        const willReplay = isSessionExpiry && !isReplayExcluded(error.config);
+
+        if (!willReplay && !error.config?.suppressGlobalErrorHandler) {
             const globalRequestErrorEvent = new CustomEvent('global-axios-error', { detail: error });
             document.dispatchEvent(globalRequestErrorEvent);
         }
-        // Check for session expiration errors (401 Unauthorized)
-        if ([401].includes(error?.response?.status)) {
+
+        if (isSessionExpiry) {
             const authenticationRequiredEvent = new CustomEvent('authentication-required', { detail: error });
             document.dispatchEvent(authenticationRequiredEvent);
+
+            if (willReplay) {
+                return queueForSessionReplay(error.config);
+            }
         }
         return Promise.reject(error);
     },

--- a/enferno/static/js/common/config.js
+++ b/enferno/static/js/common/config.js
@@ -61,7 +61,10 @@ const validationRules = {
             try {
               if (v === initialUsername) return onResponse(true), resolve(true);
       
-              await axios.post('/admin/api/checkuser/', { item: v }, { suppressGlobalErrorHandler: true });
+              await axios.post('/admin/api/checkuser/', { item: v }, {
+                suppressGlobalErrorHandler: true,
+                suppressSessionReplay: true
+              });
               onResponse(true);
               resolve(true);
             } catch (err) {
@@ -90,7 +93,10 @@ const validationRules = {
       
             passwordCheckTimeout = setTimeout(async () => {
               try {
-                await axios.post('/admin/api/password/', { password: v }, { suppressGlobalErrorHandler: true });
+                await axios.post('/admin/api/password/', { password: v }, {
+                  suppressGlobalErrorHandler: true,
+                  suppressSessionReplay: true
+                });
                 onResponse(true);
                 resolve(true);
             } catch (err) {
@@ -337,10 +343,22 @@ function isSilentPollRequest(config) {
 
 function isReplayExcluded(config) {
     if (!config) return true;
+    if (config.suppressSessionReplay) return true;
     if (config._sessionReplayed) return true;
     if (isSilentPollRequest(config)) return true;
     const url = config.url || '';
     return SESSION_REPLAY_EXCLUDED_PATHS.some(path => url === path || url.startsWith(`${path}/`) || url.startsWith(`${path}?`));
+}
+
+function isReplayableMutation(config) {
+    return ['post', 'put', 'patch', 'delete'].includes((config?.method || 'get').toLowerCase());
+}
+
+// A 401 carrying reauth_required is a freshness/step-up challenge, not a
+// plain expired session: the caller must consciously redo the privileged
+// action after proving freshness, so it is never auto-replayed.
+function isReauthRequiredResponse(error) {
+    return Boolean(error?.response?.data?.response?.reauth_required);
 }
 
 // Requests dropped by a 401 mid-flight are queued here instead of being
@@ -354,16 +372,14 @@ function queueForSessionReplay(config) {
     });
 }
 
-async function drainSessionReplayQueue() {
+function drainSessionReplayQueue() {
     const pending = sessionReplayQueue.splice(0, sessionReplayQueue.length);
-    for (const { config, resolve, reject } of pending) {
-        try {
+    return Promise.allSettled(
+        pending.map(({ config, resolve, reject }) => {
             const replayConfig = { ...config, _sessionReplayed: true };
-            resolve(await axios.request(replayConfig));
-        } catch (error) {
-            reject(error);
-        }
-    }
+            return axios.request(replayConfig).then(resolve, reject);
+        }),
+    );
 }
 
 //global axios response interceptor - handles standardized API responses and global error handling
@@ -389,7 +405,11 @@ axios.interceptors.response.use(
         const isSessionExpiry = error?.response?.status === 401;
         // A request about to be queued for replay isn't a failure yet, so
         // it must not surface an error toast ahead of the real outcome.
-        const willReplay = isSessionExpiry && !isReplayExcluded(error.config);
+        const willReplay =
+            isSessionExpiry &&
+            isReplayableMutation(error.config) &&
+            !isReplayExcluded(error.config) &&
+            !isReauthRequiredResponse(error);
 
         if (!willReplay && !error.config?.suppressGlobalErrorHandler) {
             const globalRequestErrorEvent = new CustomEvent('global-axios-error', { detail: error });

--- a/enferno/static/js/mixins/reauth-mixin.js
+++ b/enferno/static/js/mixins/reauth-mixin.js
@@ -32,9 +32,17 @@ const reauthMixin = {
       if (!this.isSignInDialogVisible && !this.isReauthDialogVisible) return;
 
       // Same reasoning as onVisibilityChange: a sibling tab signing in only
-      // proves the session exists, not that this tab's freshness reauth
+      // proves *a* session exists, not that this tab's freshness reauth
       // requirement was satisfied.
       if (this.isReauthDialogVisible) return;
+
+      // A different account signing in elsewhere is not this tab's session
+      // coming back - completing here would replay this tab's pending
+      // requests (e.g. an unsaved bulletin) under the other account's
+      // cookie. Only self-close when the restored session matches who this
+      // tab was signed in as.
+      const [restoredUsername] = event.newValue.split('|');
+      if (!this.isSameUsername(restoredUsername, window.__username__)) return;
 
       this.completeAuthentication();
     },
@@ -50,7 +58,15 @@ const reauthMixin = {
       if (this.isReauthDialogVisible) return;
 
       try {
-        await axios.get('/admin/api/session-check', { suppressGlobalErrorHandler: true });
+        const response = await axios.get('/admin/api/session-check', { suppressGlobalErrorHandler: true });
+
+        // The browser's cookie jar is shared across tabs: if a different
+        // account signed in here since this tab loaded, session-check now
+        // succeeds under that other account. That is not this tab's session
+        // coming back, and completing here would replay this tab's pending
+        // requests (e.g. an unsaved bulletin) under someone else's account.
+        if (!this.isSameUsername(response?.data?.username, window.__username__)) return;
+
         this.completeAuthentication();
       } catch (error) {
         // Still expired - keep dialog open
@@ -212,8 +228,13 @@ const reauthMixin = {
     broadcastSessionRestored() {
       try {
         // Value must change on every write so sibling tabs' storage listeners
-        // fire even if a previous signal was never cleared.
-        localStorage.setItem(SESSION_RESTORED_STORAGE_KEY, String(Date.now()));
+        // fire even if a previous signal was never cleared. Username is
+        // included so sibling tabs can tell a same-account restore (safe to
+        // auto-complete) apart from a different account signing in on this
+        // browser (must not silently replay this tab's pending requests
+        // under someone else's session).
+        const username = this.signInForm.username || window.__username__ || '';
+        localStorage.setItem(SESSION_RESTORED_STORAGE_KEY, `${Date.now()}|${username}`);
       } catch (error) {
         // Storage unavailable; other tabs simply won't self-close their dialog.
       }
@@ -288,6 +309,12 @@ const reauthMixin = {
       const reauthRequired = Boolean(evt?.response?.data?.response?.reauth_required);
 
       return reauthRequired;
+    },
+    isSameUsername(a, b) {
+      // Login is case-insensitive server-side (SECURITY_USER_IDENTITY_ATTRIBUTES),
+      // so "Alice" typed at sign-in and a stored "alice" are the same account.
+      if (!a || !b) return false;
+      return a.toLowerCase() === b.toLowerCase();
     }
   },
 };

--- a/enferno/static/js/mixins/reauth-mixin.js
+++ b/enferno/static/js/mixins/reauth-mixin.js
@@ -23,12 +23,17 @@ const reauthMixin = {
     async onVisibilityChange() {
       if (document.visibilityState !== 'visible') return; // only run when tab becomes active
 
-      // Only check if dialog is visible
-      if (!(this.isSignInDialogVisible || this.isReauthDialogVisible)) return;
-      
+      if (!this.isSignInDialogVisible && !this.isReauthDialogVisible) return;
+
+      // A session-check only proves the session exists; it cannot prove a
+      // freshness reauth requirement was satisfied. So it may auto-close the
+      // plain sign-in dialog, but the freshness reauth dialog must still be
+      // completed in this tab even if the underlying session is valid.
+      if (this.isReauthDialogVisible) return;
+
       try {
         await axios.get('/admin/api/session-check', { suppressGlobalErrorHandler: true });
-        this.resetState(); // Session restored - close dialog
+        this.completeAuthentication();
       } catch (error) {
         // Still expired - keep dialog open
       }
@@ -59,6 +64,10 @@ const reauthMixin = {
       this.twoFaSelectForm = null;
       this.verificationCode = null;
       this.signInStep = 'sign-in';
+    },
+    completeAuthentication() {
+      this.resetState();
+      drainSessionReplayQueue();
     },
     async signIn() {
       try {
@@ -179,8 +188,7 @@ const reauthMixin = {
       }
 
       this.showSnack('Authentication successful');
-      this.resetState();
-      drainSessionReplayQueue();
+      this.completeAuthentication();
     },
     async select2FAMethod() {
       try {

--- a/enferno/static/js/mixins/reauth-mixin.js
+++ b/enferno/static/js/mixins/reauth-mixin.js
@@ -12,7 +12,6 @@ const reauthMixin = {
     twoFaSelectForm: null,
     verificationCode: null,
     signInStep: 'sign-in',
-    callbackQueue: []
   }),
   created () {
     document.addEventListener('authentication-required', this.showLoginDialog);
@@ -108,9 +107,6 @@ const reauthMixin = {
 
         // Handle success
         this.handleLoginResponse();
-
-        // Run callbacks in queue
-        await this.executeCallbackQueue();
       } catch (err) {
         this.signInErrorMessage = handleRequestError(err);
       } finally {
@@ -184,6 +180,7 @@ const reauthMixin = {
 
       this.showSnack('Authentication successful');
       this.resetState();
+      drainSessionReplayQueue();
     },
     async select2FAMethod() {
       try {
@@ -250,21 +247,6 @@ const reauthMixin = {
       if (!csrfToken) this.signInErrorMessage = "Failed to retrieve CSRF token.";
 
       return csrfToken;
-    },
-    addToCallbackQueueIfReauthRequired(error, callbacks) {
-      if (!this.isReauthRequired(error)) return;
-
-      if (Array.isArray(callbacks)) {
-          callbacks.forEach(callback => this.callbackQueue.push(callback));
-      } else {
-          this.callbackQueue.push(callbacks);
-      }
-    },
-    async executeCallbackQueue() {
-      for (const callback of this.callbackQueue) {
-        await callback();
-      }
-      this.callbackQueue = [];
     },
     isReauthRequired(evt) {
       const reauthRequired = Boolean(evt?.response?.data?.response?.reauth_required);

--- a/enferno/templates/setup_wizard.html
+++ b/enferno/templates/setup_wizard.html
@@ -543,7 +543,7 @@
 
                 importDefaultData() {
                     this.loading = true;
-                    api.post('/api/import-data')
+                    api.post('/api/import-data', undefined, { suppressSessionReplay: true })
                         .then(response => {
                             this.dataImported = true;
                             this.step = 5; // Move to the next step only if import is successful
@@ -575,7 +575,7 @@
 
                 reloadApp() {
                     this.overlay = true;
-                    api.post('/admin/api/reload/')
+                    api.post('/admin/api/reload/', undefined, { suppressSessionReplay: true })
                     this.waitForReload();
                 },
 
@@ -583,7 +583,7 @@
                     this.loading = true;
                     api.put('/api/complete-setup/', {
                         conf: this.cfg
-                    })
+                    }, { suppressSessionReplay: true })
                     .then(response => {
                         this.reloadApp();
                     })


### PR DESCRIPTION
## Description
Fixes a bug where a 401 from session expiry dropped the request silently — if it was a save, the user could think it went through when it didn't.

Now the request is queued, the sign-in dialog opens, and once the user re-authenticates it replays automatically. Freshness/step-up challenges are excluded and still require a manual retry. Also fixed two role management actions (save, CSV import) that had no error handling at all, which meant a failed freshness reauth there gave no feedback. Old callbackQueue mechanism removed.

## How to Test
1. Fill a new bulletin form, before clicking save, on another tab or device logout all sessions from user, then go back to form and click save, form should return a 401 and dialog should appear, after sign in it should replay request.
2. Confirm it only saves once
3. Let freshness expire (System Administration save), verify the "Verify Password" dialog shows and the save does NOT auto-replay — must click Save again.
4. Setup wizard still works end to end.

## Jira ID (if applicable)
[BYNT-1764](https://syriajustice.atlassian.net/browse/BYNT-1764)

[BYNT-1764]: https://syriajustice.atlassian.net/browse/BYNT-1764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ