### PR TITLE
chore: enable CodeRabbit automatic reviews with vendored paths excluded

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,49 @@
+# CodeRabbit configuration
+# Docs: https://docs.coderabbit.ai/reference/yaml-template
+#
+# Kept in the repo rather than the CodeRabbit dashboard so the review policy is
+# versioned and reviewable like any other config.
+
+language: en-US
+
+reviews:
+  # Balanced feedback. "assertive" is noticeably nitpicky on a codebase this
+  # size; "quiet" drops too much to be worth the round trip.
+  profile: chill
+
+  # Advisory only. This must never gate a merge: it is non-deterministic, and a
+  # required check that an LLM can fail at random is worse than no check.
+  request_changes_workflow: false
+
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - main
+
+  path_filters:
+    # Vendored third-party JavaScript. We never hand-edit these; they change
+    # only by wholesale upgrade, so there is nothing for a reviewer to say.
+    # Library CVEs are retire.js's job, not the reviewer's.
+    - "!enferno/static/js/tinymce/**"
+    - "!enferno/static/js/videojs/**"
+    - "!enferno/static/js/lightgallery/**"
+    - "!enferno/static/js/jsondiffpatch/**"
+    - "!enferno/static/js/dropzone/**"
+    - "!enferno/static/js/pdf.js/**"
+    - "!enferno/static/js/croppr/**"
+    - "!enferno/static/js/qrcodejs/**"
+    - "!enferno/static/js/jszip/**"
+    - "!enferno/static/js/docx-preview/**"
+    - "!enferno/static/js/leaflet*.js"
+    - "!enferno/static/js/Leaflet.*.js"
+    - "!enferno/static/js/vue*.js"
+    - "!enferno/static/js/vuedraggable.umd.js"
+    - "!enferno/static/js/tinymce-vue.min.js"
+    - "!**/*.min.js"
+    - "!**/*.min.mjs"
+    # Generated or machine-managed files
+    - "!enferno/translations/**"
+    - "!uv.lock"
+    - "!docs/package-lock.json"
+    - "!migrations/versions/**"


### PR DESCRIPTION
## Summary

Turns CodeRabbit's automatic PR reviews on, and moves the review policy into the repo instead of the dashboard.

CodeRabbit is already installed here and free for public repositories, but auto review is switched off in their UI, so it only ran when someone remembered to invoke it manually. In practice that meant almost never.

## Why the config lives here

Keeping it in `.coderabbit.yaml` makes the review policy versioned and reviewable like any other config, rather than a setting one person changed in a web UI that nobody else can see.

## Choices

- `profile: chill` - balanced. `assertive` is noticeably nitpicky on a codebase this size, `quiet` drops too much to justify the round trip.
- `request_changes_workflow: false` - advisory only. This must never gate a merge: it is non-deterministic, and a required check that can fail at random is worse than no check at all.
- `auto_review.base_branches: [main]`, drafts excluded.

## Path filters

Vendored third-party JavaScript is excluded: TinyMCE, Video.js, Lightgallery, jsondiffpatch, Dropzone, PDF.js, Croppr, qrcodejs, JSZip, docx-preview, the loose Leaflet and Vue bundles, and any `.min.js` / `.min.mjs`.

We never hand-edit those files. They change only by wholesale upgrade, so there is nothing for a reviewer to comment on, and library CVEs are retire.js's job. That leaves review focused on `components/`, `mixins/`, `common/` and `utils/`, which is the JavaScript we actually write.

Also excluded: translation catalogs, `uv.lock`, `docs/package-lock.json`, and Alembic revisions, all machine-generated.

## Notes

This is advisory tooling, not a security control, and it does not change any required check or replace anything currently running.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository-level automated code review configuration.
  * Configured non-blocking reviews for eligible changes targeting the main branch.
  * Excluded generated, vendored, localized, dependency-lock, and migration files from automated review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->